### PR TITLE
feat: add syncRole and syncRoles to propagate role-definition changes

### DIFF
--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -580,6 +580,7 @@ describe("Authz class", () => {
         addRelationUnified: "unified.addRelationUnified",
         removeRelationUnified: "unified.removeRelationUnified",
         recomputeUser: "unified.recomputeUser",
+        syncRoleAction: "unified.syncRoleAction",
       },
       indexed: {
         hasRoleFast: "indexed.hasRoleFast",
@@ -1826,6 +1827,100 @@ describe("Authz class", () => {
       );
     });
   });
+
+  describe("syncRole", () => {
+    it("should call unified.syncRoleAction with the configured rolePermissionsMap", async () => {
+      const component = createMockComponent();
+      const authz = new Authz(component, { permissions, roles, tenantId: "test-tenant" });
+
+      const ctx = {
+        runQuery: vi.fn(),
+        runMutation: vi.fn(),
+        runAction: vi.fn().mockResolvedValue({ usersProcessed: 3 }),
+      };
+
+      const result = await authz.syncRole(ctx, "admin");
+
+      expect(result).toEqual({ usersProcessed: 3 });
+      expect(ctx.runAction).toHaveBeenCalledWith(
+        component.unified.syncRoleAction,
+        {
+          tenantId: "test-tenant",
+          role: "admin",
+          rolePermissionsMap: {
+            admin: [
+              "documents:create",
+              "documents:read",
+              "documents:update",
+              "documents:delete",
+            ],
+            viewer: ["documents:read"],
+          },
+          policyClassifications: undefined,
+        }
+      );
+    });
+
+    it("should throw when role is not in the configured catalog", async () => {
+      const component = createMockComponent();
+      const authz = new Authz(component, { permissions, roles, tenantId: "test-tenant" });
+
+      const ctx = {
+        runQuery: vi.fn(),
+        runMutation: vi.fn(),
+        runAction: vi.fn(),
+      };
+
+      await expect(
+        // @ts-expect-error — intentionally bypassing type check to verify runtime guard
+        authz.syncRole(ctx, "nonexistent")
+      ).rejects.toThrow('Role "nonexistent" not found in role catalog');
+      expect(ctx.runAction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("syncRoles", () => {
+    it("should call syncRoleAction once per role and aggregate counts", async () => {
+      const component = createMockComponent();
+      const authz = new Authz(component, { permissions, roles, tenantId: "test-tenant" });
+
+      const ctx = {
+        runQuery: vi.fn(),
+        runMutation: vi.fn(),
+        runAction: vi
+          .fn()
+          .mockResolvedValueOnce({ usersProcessed: 5 }) // admin
+          .mockResolvedValueOnce({ usersProcessed: 12 }), // viewer
+      };
+
+      const result = await authz.syncRoles(ctx);
+
+      expect(result).toEqual({ rolesProcessed: 2, usersProcessed: 17 });
+      expect(ctx.runAction).toHaveBeenCalledTimes(2);
+    });
+
+    it("should be a no-op when no roles are configured", async () => {
+      const component = createMockComponent();
+      const emptyPermissions = definePermissions({ noop: { read: true } });
+      const emptyRoles = defineRoles(emptyPermissions, {});
+      const authz = new Authz(component, {
+        permissions: emptyPermissions,
+        roles: emptyRoles,
+        tenantId: "test-tenant",
+      });
+
+      const ctx = {
+        runQuery: vi.fn(),
+        runMutation: vi.fn(),
+        runAction: vi.fn(),
+      };
+
+      const result = await authz.syncRoles(ctx);
+
+      expect(result).toEqual({ rolesProcessed: 0, usersProcessed: 0 });
+      expect(ctx.runAction).not.toHaveBeenCalled();
+    });
+  });
 });
 
 // ============================================================================
@@ -2104,6 +2199,7 @@ describe("Authz alias (via Authz)", () => {
         addRelationUnified: "unified.addRelationUnified",
         removeRelationUnified: "unified.removeRelationUnified",
         recomputeUser: "unified.recomputeUser",
+        syncRoleAction: "unified.syncRoleAction",
       },
       indexed: {
         hasRoleFast: "indexed.hasRoleFast",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1103,25 +1103,103 @@ export class Authz<
   }
 
   /**
+   * Build policy classifications from the configured policies. All policies
+   * are classified as "deferred" so they are re-evaluated at read time.
+   * Returns `undefined` when no policies are configured (matches the
+   * optional argument shape on the component-side mutations).
+   */
+  private buildPolicyClassifications():
+    | Record<string, "deferred" | "allow" | "deny" | null>
+    | undefined {
+    if (!this.options.policies) return undefined;
+    const entries = Object.entries(
+      this.options.policies as Record<string, { type?: string }>,
+    );
+    if (entries.length === 0) return undefined;
+    const map: Record<string, "deferred" | "allow" | "deny" | null> = {};
+    for (const [name] of entries) {
+      map[name] = "deferred";
+    }
+    return map;
+  }
+
+  /**
    * Recompute all indexed data for a user (effectiveRoles, effectivePermissions).
    * Useful when role definitions change and you need to rebuild the index.
    */
   async recomputeUser(ctx: MutationCtx | ActionCtx, userId: string): Promise<void> {
     validateUserId(userId);
-    // Build policy classifications from policies config
-    // All policies are classified as "deferred" so they are evaluated at read time in can().
-    const policyClassifications: Record<string, "deferred" | "allow" | "deny" | null> = {};
-    if (this.options.policies) {
-      for (const [name] of Object.entries(this.options.policies as Record<string, { type?: string }>)) {
-        policyClassifications[name] = "deferred";
-      }
-    }
     await ctx.runMutation(this.component.unified.recomputeUser, {
       tenantId: this.options.tenantId,
       userId,
       rolePermissionsMap: this.buildRolePermissionsMap(),
-      policyClassifications: Object.keys(policyClassifications).length > 0 ? policyClassifications : undefined,
+      policyClassifications: this.buildPolicyClassifications(),
     });
+  }
+
+  /**
+   * Re-materialize permissions for every user holding the given role.
+   *
+   * Use after a role definition (`defineRoles(...)`) gains or loses
+   * permissions and you redeploy. Existing assignments still carry the old
+   * materialized rows in `effectivePermissions`; this rebuilds them from the
+   * current role definition while preserving direct grants/denies.
+   *
+   * Requires an action context — internally pages through assignments and
+   * runs `recomputeUser` per user. Each user is one mutation transaction;
+   * a partial failure leaves earlier users updated and stops on the failing
+   * one (rerun is safe and idempotent).
+   *
+   * @param role - Role name from the configured catalog. Type-checked.
+   * @returns Number of unique users recomputed.
+   */
+  async syncRole<RoleName extends keyof R & string>(
+    ctx: ActionCtx,
+    role: RoleName,
+  ): Promise<{ usersProcessed: number }> {
+    const roles = this.options.roles as unknown as Record<string, unknown>;
+    if (!(role in roles)) {
+      throw new Error(`Role "${String(role)}" not found in role catalog`);
+    }
+    return await ctx.runAction(this.component.unified.syncRoleAction, {
+      tenantId: this.options.tenantId,
+      role,
+      rolePermissionsMap: this.buildRolePermissionsMap(),
+      policyClassifications: this.buildPolicyClassifications(),
+    });
+  }
+
+  /**
+   * Re-materialize permissions for every user holding any role in the
+   * configured catalog. Convenience wrapper around `syncRole` that iterates
+   * across all roles.
+   *
+   * Cost is roughly `(unique users with any role) × (one mutation each)`.
+   * For a full deploy-time sync of a 10k-user app, expect tens of seconds.
+   * For very large user bases, prefer running per-role syncs in parallel
+   * (each `syncRole` call is independent).
+   */
+  async syncRoles(
+    ctx: ActionCtx,
+  ): Promise<{ rolesProcessed: number; usersProcessed: number }> {
+    const rolePermissionsMap = this.buildRolePermissionsMap();
+    const policyClassifications = this.buildPolicyClassifications();
+    const roles = Object.keys(rolePermissionsMap);
+
+    let totalUsers = 0;
+    for (const role of roles) {
+      const result = await ctx.runAction(
+        this.component.unified.syncRoleAction,
+        {
+          tenantId: this.options.tenantId,
+          role,
+          rolePermissionsMap,
+          policyClassifications,
+        },
+      );
+      totalUsers += result.usersProcessed;
+    }
+    return { rolesProcessed: roles.length, usersProcessed: totalUsers };
   }
 
   /**

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -522,6 +522,24 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         string,
         Name
       >;
+      listUserIdsWithRole: FunctionReference<
+        "query",
+        "internal",
+        {
+          paginationOpts: {
+            cursor: string | null;
+            endCursor?: string | null;
+            id?: number;
+            maximumBytesRead?: number;
+            maximumRowsRead?: number;
+            numItems: number;
+          };
+          role: string;
+          tenantId: string;
+        },
+        { continueCursor: string; isDone: boolean; userIds: Array<string> },
+        Name
+      >;
       recomputeUser: FunctionReference<
         "mutation",
         "internal",
@@ -610,6 +628,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           value: any;
         },
         string,
+        Name
+      >;
+      syncRoleAction: FunctionReference<
+        "action",
+        "internal",
+        {
+          policyClassifications?: Record<
+            string,
+            null | "allow" | "deny" | "deferred"
+          >;
+          role: string;
+          rolePermissionsMap: Record<string, Array<string>>;
+          tenantId: string;
+        },
+        { usersProcessed: number },
         Name
       >;
     };

--- a/src/component/tests/issue-30-role-definition-sync.test.ts
+++ b/src/component/tests/issue-30-role-definition-sync.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Regression tests for issue #30: role-definition changes propagate to
+ * existing assignments via `syncRoleAction` / `syncRoles`.
+ *
+ * https://github.com/dbjpanda/convex-authz/issues/30
+ *
+ * The bug: `effectivePermissions` is materialized at role-assignment time
+ * using the role's permission list at that moment. Changing the role
+ * definition in client code does not retroactively update existing rows.
+ *
+ * The fix: `syncRoleAction` walks every assignment of a role within a
+ * tenant and calls `recomputeUser` per user, rebuilding the effective rows
+ * from the supplied (new) permission map. Direct grants and denies survive.
+ */
+
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "../schema.js";
+import { api } from "../_generated/api.js";
+
+const modules = import.meta.glob("../**/*.ts");
+const TENANT = "tenant-issue-30";
+
+describe("issue #30 — role-definition sync via syncRoleAction", () => {
+  test("syncRoleAction picks up role-definition changes for existing assignments", async () => {
+    const t = convexTest(schema, modules);
+
+    // Assign the `member` role with the OLD permission list.
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: TENANT,
+      userId: "alice",
+      role: "member",
+      rolePermissions: ["organizations:read"],
+    });
+
+    // Sanity: the new permission isn't visible yet.
+    const before = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "alice",
+      permission: "members:list",
+    });
+    expect(before.allowed).toBe(false);
+
+    // Sync the role with the NEW permission list (as if the role definition
+    // in client code gained `members:list` and the app redeployed).
+    const result = await t.action(api.unified.syncRoleAction, {
+      tenantId: TENANT,
+      role: "member",
+      rolePermissionsMap: {
+        member: ["organizations:read", "members:list"],
+      },
+    });
+    expect(result.usersProcessed).toBe(1);
+
+    // The new permission now resolves for the existing assignment.
+    const after = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "alice",
+      permission: "members:list",
+    });
+    expect(after.allowed).toBe(true);
+
+    // The old permission still works.
+    const stillThere = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "alice",
+      permission: "organizations:read",
+    });
+    expect(stillThere.allowed).toBe(true);
+  });
+
+  test("syncRoleAction preserves direct grants and direct denies", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: TENANT,
+      userId: "carol",
+      role: "member",
+      rolePermissions: ["organizations:read"],
+    });
+
+    // Direct grant outside the role.
+    await t.mutation(api.unified.grantPermissionUnified, {
+      tenantId: TENANT,
+      userId: "carol",
+      permission: "billing:export",
+      reason: "one-off audit",
+    });
+
+    // Direct deny that overrides a role-granted permission.
+    await t.mutation(api.unified.denyPermissionUnified, {
+      tenantId: TENANT,
+      userId: "carol",
+      permission: "organizations:read",
+      reason: "compliance hold",
+    });
+
+    await t.action(api.unified.syncRoleAction, {
+      tenantId: TENANT,
+      role: "member",
+      rolePermissionsMap: {
+        member: ["organizations:read", "members:list"],
+      },
+    });
+
+    // Direct grant survives.
+    const grant = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "carol",
+      permission: "billing:export",
+    });
+    expect(grant.allowed).toBe(true);
+
+    // Direct deny survives — still blocks the role-granted permission.
+    const deny = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "carol",
+      permission: "organizations:read",
+    });
+    expect(deny.allowed).toBe(false);
+
+    // The new role permission is now reachable.
+    const newPerm = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "carol",
+      permission: "members:list",
+    });
+    expect(newPerm.allowed).toBe(true);
+  });
+
+  test("syncRoleAction respects tenant isolation", async () => {
+    const t = convexTest(schema, modules);
+
+    // Same role name, two tenants. Sync runs against tenant-a only.
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: "tenant-a",
+      userId: "alice",
+      role: "member",
+      rolePermissions: ["organizations:read"],
+    });
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: "tenant-b",
+      userId: "bob",
+      role: "member",
+      rolePermissions: ["organizations:read"],
+    });
+
+    const result = await t.action(api.unified.syncRoleAction, {
+      tenantId: "tenant-a",
+      role: "member",
+      rolePermissionsMap: {
+        member: ["organizations:read", "members:list"],
+      },
+    });
+    // Only one user in tenant-a — bob in tenant-b must not be touched.
+    expect(result.usersProcessed).toBe(1);
+
+    const aliceCanList = await t.query(api.unified.checkPermission, {
+      tenantId: "tenant-a",
+      userId: "alice",
+      permission: "members:list",
+    });
+    expect(aliceCanList.allowed).toBe(true);
+
+    const bobCanList = await t.query(api.unified.checkPermission, {
+      tenantId: "tenant-b",
+      userId: "bob",
+      permission: "members:list",
+    });
+    expect(bobCanList.allowed).toBe(false);
+  });
+
+  test("syncRoleAction dedupes users with the same role in multiple scopes", async () => {
+    const t = convexTest(schema, modules);
+
+    // alice has `member` role globally AND scoped to a team.
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: TENANT,
+      userId: "alice",
+      role: "member",
+      rolePermissions: ["organizations:read"],
+    });
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: TENANT,
+      userId: "alice",
+      role: "member",
+      rolePermissions: ["organizations:read"],
+      scope: { type: "team", id: "team-1" },
+    });
+
+    const result = await t.action(api.unified.syncRoleAction, {
+      tenantId: TENANT,
+      role: "member",
+      rolePermissionsMap: {
+        member: ["organizations:read", "members:list"],
+      },
+    });
+
+    // Two assignments, but only one unique user → one recompute.
+    expect(result.usersProcessed).toBe(1);
+  });
+
+  test("syncRoleAction paginates across many users", async () => {
+    const t = convexTest(schema, modules);
+
+    // Page size in syncRoleAction is 50; create 60 users to force a second page.
+    const userCount = 60;
+    for (let i = 0; i < userCount; i++) {
+      await t.mutation(api.unified.assignRoleUnified, {
+        tenantId: TENANT,
+        userId: `user_${i}`,
+        role: "member",
+        rolePermissions: ["organizations:read"],
+      });
+    }
+
+    const result = await t.action(api.unified.syncRoleAction, {
+      tenantId: TENANT,
+      role: "member",
+      rolePermissionsMap: {
+        member: ["organizations:read", "members:list"],
+      },
+    });
+    expect(result.usersProcessed).toBe(userCount);
+
+    // Spot-check a user from the first batch and one from the second.
+    const first = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "user_0",
+      permission: "members:list",
+    });
+    expect(first.allowed).toBe(true);
+
+    const last = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: `user_${userCount - 1}`,
+      permission: "members:list",
+    });
+    expect(last.allowed).toBe(true);
+  });
+
+  test("syncRoleAction is a no-op when no users hold the role", async () => {
+    const t = convexTest(schema, modules);
+
+    const result = await t.action(api.unified.syncRoleAction, {
+      tenantId: TENANT,
+      role: "member",
+      rolePermissionsMap: { member: ["organizations:read"] },
+    });
+    expect(result.usersProcessed).toBe(0);
+  });
+});

--- a/src/component/unified.ts
+++ b/src/component/unified.ts
@@ -11,7 +11,9 @@
  */
 
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server.js";
+import { paginationOptsValidator } from "convex/server";
+import { action, mutation, query } from "./_generated/server.js";
+import { api } from "./_generated/api.js";
 import { scopeValidator } from "./validators.js";
 import { isExpired, matchesPermissionPattern } from "./helpers.js";
 
@@ -1857,3 +1859,116 @@ export const revokeAllRolesUnified = mutation({
     return revokedCount;
   },
 });
+
+/**
+ * List unique user IDs in a tenant who hold a given role.
+ *
+ * Helper for `syncRoleAction`. Pages over `roleAssignments` via the
+ * `by_tenant_role` index and dedupes within each page (a user can hold the
+ * same role in multiple scopes; we only need the userId once per recompute).
+ *
+ * Cross-page dedup is the caller's responsibility — a user split across pages
+ * by Convex's pagination cursor will appear in multiple batches.
+ */
+export const listUserIdsWithRole = query({
+  args: {
+    tenantId: v.string(),
+    role: v.string(),
+    paginationOpts: paginationOptsValidator,
+  },
+  returns: v.object({
+    userIds: v.array(v.string()),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_tenant_role", (q) =>
+        q.eq("tenantId", args.tenantId).eq("role", args.role),
+      )
+      .paginate(args.paginationOpts);
+
+    const uniqueUserIds = [...new Set(result.page.map((a) => a.userId))];
+
+    return {
+      userIds: uniqueUserIds,
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
+
+/**
+ * Sync Role
+ *
+ * Re-materialize `effectivePermissions` and `effectiveRoles` for every user
+ * who currently holds the given role, using the supplied permission map as
+ * the new role definition.
+ *
+ * Use case: a role definition in client code (`defineRoles(...)`) gained or
+ * lost permissions, the app redeployed, and existing assignments still carry
+ * the old materialized rows. `syncRoleAction` walks every assignment and
+ * calls `recomputeUser` per user.
+ *
+ * Behavior preserved across recompute:
+ *   - Direct grants (`directGrant: true` rows in `effectivePermissions`)
+ *   - Direct denies (`directDeny: true` rows in `effectivePermissions`)
+ *   These come from `permissionOverrides` and are intentionally untouched.
+ *
+ * Scale: each user is recomputed in its own mutation transaction. The action
+ * iterates through pages of 50 unique userIds at a time. For very large user
+ * bases, run the action multiple times or shard by tenant.
+ */
+export const syncRoleAction = action({
+  args: {
+    tenantId: v.string(),
+    role: v.string(),
+    rolePermissionsMap: v.record(v.string(), v.array(v.string())),
+    policyClassifications: v.optional(
+      v.record(
+        v.string(),
+        v.union(
+          v.null(),
+          v.literal("allow"),
+          v.literal("deny"),
+          v.literal("deferred"),
+        ),
+      ),
+    ),
+  },
+  returns: v.object({ usersProcessed: v.number() }),
+  handler: async (ctx, args) => {
+    let cursor: string | null = null;
+    const seen = new Set<string>();
+
+    while (true) {
+      const batch: {
+        userIds: string[];
+        isDone: boolean;
+        continueCursor: string;
+      } = await ctx.runQuery(api.unified.listUserIdsWithRole, {
+        tenantId: args.tenantId,
+        role: args.role,
+        paginationOpts: { numItems: 50, cursor },
+      });
+
+      for (const userId of batch.userIds) {
+        if (seen.has(userId)) continue;
+        seen.add(userId);
+        await ctx.runMutation(api.unified.recomputeUser, {
+          tenantId: args.tenantId,
+          userId,
+          rolePermissionsMap: args.rolePermissionsMap,
+          policyClassifications: args.policyClassifications,
+        });
+      }
+
+      if (batch.isDone) break;
+      cursor = batch.continueCursor;
+    }
+
+    return { usersProcessed: seen.size };
+  },
+});
+


### PR DESCRIPTION
Closes #30.

## Summary

When a role definition (`defineRoles(...)`) gains or loses permissions in client code and the app redeploys, existing assignments still carry the permission list that was materialized at assignment time in `effectivePermissions`. There's no automatic mechanism for the unified architecture to detect that the in-memory role catalog drifted from materialized rows.

This PR adds an opt-in re-materialization API that walks every assignment for a role within a tenant and rebuilds the effective rows from the supplied (current) permission map.

## What's new

- **`unified.listUserIdsWithRole`** (component query) — paginated lookup over `roleAssignments` by the existing `by_tenant_role` index, returning unique userIds per page.
- **`unified.syncRoleAction`** (component action) — walks every assignment for a role within a tenant, dedupes userIds across pages, calls `recomputeUser` per user. Each user is one mutation transaction (partial failures stop on the failing user; rerun is idempotent).
- **`Authz.syncRole(ctx, role)`** — type-safe client wrapper that validates the role name against the configured catalog.
- **`Authz.syncRoles(ctx)`** — convenience wrapper that iterates all roles and aggregates counts.

## What didn't change

- No schema changes — the `by_tenant_role` index this needs already existed.
- No changes to the public surface of `assignRole`, `recomputeUser`, etc. The existing per-user `recomputeUser` primitive is the building block for the new bulk action.
- Override semantics: direct grants and direct denies (`directGrant: true` / `directDeny: true` rows in `effectivePermissions`, sourced from `permissionOverrides`) are preserved across recompute. Verified by a regression test.

## Refactor included

`buildPolicyClassifications()` extracted as a private helper on `Authz` to share the deferred-policy classification logic between `recomputeUser`, `syncRole`, and `syncRoles`. Behavior unchanged.

## Tests

**6 component-layer e2e regression tests** in `src/component/tests/issue-30-role-definition-sync.test.ts`:

- Role-definition propagation (the headline fix)
- Direct-grant / direct-deny preservation
- Tenant isolation (sync in tenant-a doesn't touch tenant-b)
- User dedup across multiple scopes for the same role
- Pagination across >50 users (60-user fixture forces a second page)
- No-op when no users hold the role

**4 client-layer mock tests** in `src/client/index.test.ts`:

- `syncRole` calls `unified.syncRoleAction` with the configured `rolePermissionsMap`
- `syncRole` throws `Error("Role \"X\" not found in role catalog")` for unknown roles
- `syncRoles` aggregates counts across all roles
- `syncRoles` is a no-op when the catalog is empty

Total: **10 new tests, 669 passing repo-wide**.

## Scale notes

Each user is recomputed in its own mutation transaction. The action iterates 50 unique userIds per page. For ~10k-user apps a single `syncRole` call completes well within action timeouts. For very large user bases, prefer per-role parallel calls (each `syncRole` is independent) or shard by tenant.

## Test plan

- [ ] `Test and lint` CI check passes (build + typecheck + lint + 669 tests under TS 6 / vitest 4)
- [ ] `Validate PR title` CI check passes — `feat:` triggers the next minor version bump on next release
- [ ] After merge, release-please opens a release PR for `2.3.0` with this entry under `### Features`
- [ ] When that release PR is merged, `2.3.0` publishes to npm via OIDC (first real test of the Trusted Publishing flow end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)