### PR TITLE
feat: add syncRole and syncRoles APIs for role-definition propagation

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -142,6 +142,40 @@ permissions:
 `id-token: write` is the GitHub-side half of OIDC. Removing it would break
 publishing immediately.
 
+## Configuration migration: changing the tag pattern
+
+Changing the `include-component-in-tag` (or any other tag-shape) field in
+`release-please-config.json` is **retroactive**: release-please's "what was
+the last release" lookup is a tag-pattern scan, not a manifest read. Old
+tags created under the previous pattern stop matching the new pattern and
+become invisible to release-please.
+
+When that happens, release-please falls back to the highest tag that still
+matches the new pattern, treats every commit since then as unreleased, and
+opens a release PR that re-includes commits from already-shipped versions
+(usually with duplicated `feat:` entries — that is the giveaway).
+
+**If you change the tag pattern, you must backfill matching tags for the
+current and recent release(s).** Example (tag-prefix drop, as done in
+PR #29):
+
+```sh
+# The old tag was convex-authz-vX.Y.Z, the new pattern is vX.Y.Z.
+# Backfill v2.2.0 pointing at the same commit as the legacy tag.
+git tag v2.2.0 "$(git rev-parse convex-authz-v2.2.0)"
+git push origin v2.2.0
+```
+
+If you skip this step and merge anything to `main`, release-please will
+open a wrong-version release PR. Do not merge that PR — instead, backfill
+the tag, re-run the release-please workflow, and **manually close** the
+stale PR (release-please does not auto-close PRs it has already created
+when conditions change).
+
+Leave the legacy tag in place. It costs nothing and may be referenced by
+external systems (npm provenance verification, blog posts, archive
+crawlers).
+
 ## Emergency: manual publish (break-glass only)
 
 Only use this if OIDC is broken (e.g. npm trusted publishing outage) AND a

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -580,6 +580,7 @@ describe("Authz class", () => {
         addRelationUnified: "unified.addRelationUnified",
         removeRelationUnified: "unified.removeRelationUnified",
         recomputeUser: "unified.recomputeUser",
+        syncRoleAction: "unified.syncRoleAction",
       },
       indexed: {
         hasRoleFast: "indexed.hasRoleFast",
@@ -1826,6 +1827,100 @@ describe("Authz class", () => {
       );
     });
   });
+
+  describe("syncRole", () => {
+    it("should call unified.syncRoleAction with the configured rolePermissionsMap", async () => {
+      const component = createMockComponent();
+      const authz = new Authz(component, { permissions, roles, tenantId: "test-tenant" });
+
+      const ctx = {
+        runQuery: vi.fn(),
+        runMutation: vi.fn(),
+        runAction: vi.fn().mockResolvedValue({ usersProcessed: 3 }),
+      };
+
+      const result = await authz.syncRole(ctx, "admin");
+
+      expect(result).toEqual({ usersProcessed: 3 });
+      expect(ctx.runAction).toHaveBeenCalledWith(
+        component.unified.syncRoleAction,
+        {
+          tenantId: "test-tenant",
+          role: "admin",
+          rolePermissionsMap: {
+            admin: [
+              "documents:create",
+              "documents:read",
+              "documents:update",
+              "documents:delete",
+            ],
+            viewer: ["documents:read"],
+          },
+          policyClassifications: undefined,
+        }
+      );
+    });
+
+    it("should throw when role is not in the configured catalog", async () => {
+      const component = createMockComponent();
+      const authz = new Authz(component, { permissions, roles, tenantId: "test-tenant" });
+
+      const ctx = {
+        runQuery: vi.fn(),
+        runMutation: vi.fn(),
+        runAction: vi.fn(),
+      };
+
+      await expect(
+        // @ts-expect-error — intentionally bypassing type check to verify runtime guard
+        authz.syncRole(ctx, "nonexistent")
+      ).rejects.toThrow('Role "nonexistent" not found in role catalog');
+      expect(ctx.runAction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("syncRoles", () => {
+    it("should call syncRoleAction once per role and aggregate counts", async () => {
+      const component = createMockComponent();
+      const authz = new Authz(component, { permissions, roles, tenantId: "test-tenant" });
+
+      const ctx = {
+        runQuery: vi.fn(),
+        runMutation: vi.fn(),
+        runAction: vi
+          .fn()
+          .mockResolvedValueOnce({ usersProcessed: 5 }) // admin
+          .mockResolvedValueOnce({ usersProcessed: 12 }), // viewer
+      };
+
+      const result = await authz.syncRoles(ctx);
+
+      expect(result).toEqual({ rolesProcessed: 2, usersProcessed: 17 });
+      expect(ctx.runAction).toHaveBeenCalledTimes(2);
+    });
+
+    it("should be a no-op when no roles are configured", async () => {
+      const component = createMockComponent();
+      const emptyPermissions = definePermissions({ noop: { read: true } });
+      const emptyRoles = defineRoles(emptyPermissions, {});
+      const authz = new Authz(component, {
+        permissions: emptyPermissions,
+        roles: emptyRoles,
+        tenantId: "test-tenant",
+      });
+
+      const ctx = {
+        runQuery: vi.fn(),
+        runMutation: vi.fn(),
+        runAction: vi.fn(),
+      };
+
+      const result = await authz.syncRoles(ctx);
+
+      expect(result).toEqual({ rolesProcessed: 0, usersProcessed: 0 });
+      expect(ctx.runAction).not.toHaveBeenCalled();
+    });
+  });
 });
 
 // ============================================================================
@@ -2104,6 +2199,7 @@ describe("Authz alias (via Authz)", () => {
         addRelationUnified: "unified.addRelationUnified",
         removeRelationUnified: "unified.removeRelationUnified",
         recomputeUser: "unified.recomputeUser",
+        syncRoleAction: "unified.syncRoleAction",
       },
       indexed: {
         hasRoleFast: "indexed.hasRoleFast",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1103,25 +1103,103 @@ export class Authz<
   }
 
   /**
+   * Build policy classifications from the configured policies. All policies
+   * are classified as "deferred" so they are re-evaluated at read time.
+   * Returns `undefined` when no policies are configured (matches the
+   * optional argument shape on the component-side mutations).
+   */
+  private buildPolicyClassifications():
+    | Record<string, "deferred" | "allow" | "deny" | null>
+    | undefined {
+    if (!this.options.policies) return undefined;
+    const entries = Object.entries(
+      this.options.policies as Record<string, { type?: string }>,
+    );
+    if (entries.length === 0) return undefined;
+    const map: Record<string, "deferred" | "allow" | "deny" | null> = {};
+    for (const [name] of entries) {
+      map[name] = "deferred";
+    }
+    return map;
+  }
+
+  /**
    * Recompute all indexed data for a user (effectiveRoles, effectivePermissions).
    * Useful when role definitions change and you need to rebuild the index.
    */
   async recomputeUser(ctx: MutationCtx | ActionCtx, userId: string): Promise<void> {
     validateUserId(userId);
-    // Build policy classifications from policies config
-    // All policies are classified as "deferred" so they are evaluated at read time in can().
-    const policyClassifications: Record<string, "deferred" | "allow" | "deny" | null> = {};
-    if (this.options.policies) {
-      for (const [name] of Object.entries(this.options.policies as Record<string, { type?: string }>)) {
-        policyClassifications[name] = "deferred";
-      }
-    }
     await ctx.runMutation(this.component.unified.recomputeUser, {
       tenantId: this.options.tenantId,
       userId,
       rolePermissionsMap: this.buildRolePermissionsMap(),
-      policyClassifications: Object.keys(policyClassifications).length > 0 ? policyClassifications : undefined,
+      policyClassifications: this.buildPolicyClassifications(),
     });
+  }
+
+  /**
+   * Re-materialize permissions for every user holding the given role.
+   *
+   * Use after a role definition (`defineRoles(...)`) gains or loses
+   * permissions and you redeploy. Existing assignments still carry the old
+   * materialized rows in `effectivePermissions`; this rebuilds them from the
+   * current role definition while preserving direct grants/denies.
+   *
+   * Requires an action context — internally pages through assignments and
+   * runs `recomputeUser` per user. Each user is one mutation transaction;
+   * a partial failure leaves earlier users updated and stops on the failing
+   * one (rerun is safe and idempotent).
+   *
+   * @param role - Role name from the configured catalog. Type-checked.
+   * @returns Number of unique users recomputed.
+   */
+  async syncRole<RoleName extends keyof R & string>(
+    ctx: ActionCtx,
+    role: RoleName,
+  ): Promise<{ usersProcessed: number }> {
+    const roles = this.options.roles as unknown as Record<string, unknown>;
+    if (!(role in roles)) {
+      throw new Error(`Role "${String(role)}" not found in role catalog`);
+    }
+    return await ctx.runAction(this.component.unified.syncRoleAction, {
+      tenantId: this.options.tenantId,
+      role,
+      rolePermissionsMap: this.buildRolePermissionsMap(),
+      policyClassifications: this.buildPolicyClassifications(),
+    });
+  }
+
+  /**
+   * Re-materialize permissions for every user holding any role in the
+   * configured catalog. Convenience wrapper around `syncRole` that iterates
+   * across all roles.
+   *
+   * Cost is roughly `(unique users with any role) × (one mutation each)`.
+   * For a full deploy-time sync of a 10k-user app, expect tens of seconds.
+   * For very large user bases, prefer running per-role syncs in parallel
+   * (each `syncRole` call is independent).
+   */
+  async syncRoles(
+    ctx: ActionCtx,
+  ): Promise<{ rolesProcessed: number; usersProcessed: number }> {
+    const rolePermissionsMap = this.buildRolePermissionsMap();
+    const policyClassifications = this.buildPolicyClassifications();
+    const roles = Object.keys(rolePermissionsMap);
+
+    let totalUsers = 0;
+    for (const role of roles) {
+      const result = await ctx.runAction(
+        this.component.unified.syncRoleAction,
+        {
+          tenantId: this.options.tenantId,
+          role,
+          rolePermissionsMap,
+          policyClassifications,
+        },
+      );
+      totalUsers += result.usersProcessed;
+    }
+    return { rolesProcessed: roles.length, usersProcessed: totalUsers };
   }
 
   /**

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -522,6 +522,24 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         string,
         Name
       >;
+      listUserIdsWithRole: FunctionReference<
+        "query",
+        "internal",
+        {
+          paginationOpts: {
+            cursor: string | null;
+            endCursor?: string | null;
+            id?: number;
+            maximumBytesRead?: number;
+            maximumRowsRead?: number;
+            numItems: number;
+          };
+          role: string;
+          tenantId: string;
+        },
+        { continueCursor: string; isDone: boolean; userIds: Array<string> },
+        Name
+      >;
       recomputeUser: FunctionReference<
         "mutation",
         "internal",
@@ -610,6 +628,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           value: any;
         },
         string,
+        Name
+      >;
+      syncRoleAction: FunctionReference<
+        "action",
+        "internal",
+        {
+          policyClassifications?: Record<
+            string,
+            null | "allow" | "deny" | "deferred"
+          >;
+          role: string;
+          rolePermissionsMap: Record<string, Array<string>>;
+          tenantId: string;
+        },
+        { usersProcessed: number },
         Name
       >;
     };

--- a/src/component/tests/issue-30-role-definition-sync.test.ts
+++ b/src/component/tests/issue-30-role-definition-sync.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Regression tests for issue #30: role-definition changes propagate to
+ * existing assignments via `syncRoleAction` / `syncRoles`.
+ *
+ * https://github.com/dbjpanda/convex-authz/issues/30
+ *
+ * The bug: `effectivePermissions` is materialized at role-assignment time
+ * using the role's permission list at that moment. Changing the role
+ * definition in client code does not retroactively update existing rows.
+ *
+ * The fix: `syncRoleAction` walks every assignment of a role within a
+ * tenant and calls `recomputeUser` per user, rebuilding the effective rows
+ * from the supplied (new) permission map. Direct grants and denies survive.
+ */
+
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import schema from "../schema.js";
+import { api } from "../_generated/api.js";
+
+const modules = import.meta.glob("../**/*.ts");
+const TENANT = "tenant-issue-30";
+
+describe("issue #30 — role-definition sync via syncRoleAction", () => {
+  test("syncRoleAction picks up role-definition changes for existing assignments", async () => {
+    const t = convexTest(schema, modules);
+
+    // Assign the `member` role with the OLD permission list.
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: TENANT,
+      userId: "alice",
+      role: "member",
+      rolePermissions: ["organizations:read"],
+    });
+
+    // Sanity: the new permission isn't visible yet.
+    const before = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "alice",
+      permission: "members:list",
+    });
+    expect(before.allowed).toBe(false);
+
+    // Sync the role with the NEW permission list (as if the role definition
+    // in client code gained `members:list` and the app redeployed).
+    const result = await t.action(api.unified.syncRoleAction, {
+      tenantId: TENANT,
+      role: "member",
+      rolePermissionsMap: {
+        member: ["organizations:read", "members:list"],
+      },
+    });
+    expect(result.usersProcessed).toBe(1);
+
+    // The new permission now resolves for the existing assignment.
+    const after = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "alice",
+      permission: "members:list",
+    });
+    expect(after.allowed).toBe(true);
+
+    // The old permission still works.
+    const stillThere = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "alice",
+      permission: "organizations:read",
+    });
+    expect(stillThere.allowed).toBe(true);
+  });
+
+  test("syncRoleAction preserves direct grants and direct denies", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: TENANT,
+      userId: "carol",
+      role: "member",
+      rolePermissions: ["organizations:read"],
+    });
+
+    // Direct grant outside the role.
+    await t.mutation(api.unified.grantPermissionUnified, {
+      tenantId: TENANT,
+      userId: "carol",
+      permission: "billing:export",
+      reason: "one-off audit",
+    });
+
+    // Direct deny that overrides a role-granted permission.
+    await t.mutation(api.unified.denyPermissionUnified, {
+      tenantId: TENANT,
+      userId: "carol",
+      permission: "organizations:read",
+      reason: "compliance hold",
+    });
+
+    await t.action(api.unified.syncRoleAction, {
+      tenantId: TENANT,
+      role: "member",
+      rolePermissionsMap: {
+        member: ["organizations:read", "members:list"],
+      },
+    });
+
+    // Direct grant survives.
+    const grant = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "carol",
+      permission: "billing:export",
+    });
+    expect(grant.allowed).toBe(true);
+
+    // Direct deny survives — still blocks the role-granted permission.
+    const deny = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "carol",
+      permission: "organizations:read",
+    });
+    expect(deny.allowed).toBe(false);
+
+    // The new role permission is now reachable.
+    const newPerm = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "carol",
+      permission: "members:list",
+    });
+    expect(newPerm.allowed).toBe(true);
+  });
+
+  test("syncRoleAction respects tenant isolation", async () => {
+    const t = convexTest(schema, modules);
+
+    // Same role name, two tenants. Sync runs against tenant-a only.
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: "tenant-a",
+      userId: "alice",
+      role: "member",
+      rolePermissions: ["organizations:read"],
+    });
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: "tenant-b",
+      userId: "bob",
+      role: "member",
+      rolePermissions: ["organizations:read"],
+    });
+
+    const result = await t.action(api.unified.syncRoleAction, {
+      tenantId: "tenant-a",
+      role: "member",
+      rolePermissionsMap: {
+        member: ["organizations:read", "members:list"],
+      },
+    });
+    // Only one user in tenant-a — bob in tenant-b must not be touched.
+    expect(result.usersProcessed).toBe(1);
+
+    const aliceCanList = await t.query(api.unified.checkPermission, {
+      tenantId: "tenant-a",
+      userId: "alice",
+      permission: "members:list",
+    });
+    expect(aliceCanList.allowed).toBe(true);
+
+    const bobCanList = await t.query(api.unified.checkPermission, {
+      tenantId: "tenant-b",
+      userId: "bob",
+      permission: "members:list",
+    });
+    expect(bobCanList.allowed).toBe(false);
+  });
+
+  test("syncRoleAction dedupes users with the same role in multiple scopes", async () => {
+    const t = convexTest(schema, modules);
+
+    // alice has `member` role globally AND scoped to a team.
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: TENANT,
+      userId: "alice",
+      role: "member",
+      rolePermissions: ["organizations:read"],
+    });
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: TENANT,
+      userId: "alice",
+      role: "member",
+      rolePermissions: ["organizations:read"],
+      scope: { type: "team", id: "team-1" },
+    });
+
+    const result = await t.action(api.unified.syncRoleAction, {
+      tenantId: TENANT,
+      role: "member",
+      rolePermissionsMap: {
+        member: ["organizations:read", "members:list"],
+      },
+    });
+
+    // Two assignments, but only one unique user → one recompute.
+    expect(result.usersProcessed).toBe(1);
+  });
+
+  test("syncRoleAction paginates across many users", async () => {
+    const t = convexTest(schema, modules);
+
+    // Page size in syncRoleAction is 50; create 60 users to force a second page.
+    const userCount = 60;
+    for (let i = 0; i < userCount; i++) {
+      await t.mutation(api.unified.assignRoleUnified, {
+        tenantId: TENANT,
+        userId: `user_${i}`,
+        role: "member",
+        rolePermissions: ["organizations:read"],
+      });
+    }
+
+    const result = await t.action(api.unified.syncRoleAction, {
+      tenantId: TENANT,
+      role: "member",
+      rolePermissionsMap: {
+        member: ["organizations:read", "members:list"],
+      },
+    });
+    expect(result.usersProcessed).toBe(userCount);
+
+    // Spot-check a user from the first batch and one from the second.
+    const first = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: "user_0",
+      permission: "members:list",
+    });
+    expect(first.allowed).toBe(true);
+
+    const last = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT,
+      userId: `user_${userCount - 1}`,
+      permission: "members:list",
+    });
+    expect(last.allowed).toBe(true);
+  });
+
+  test("syncRoleAction is a no-op when no users hold the role", async () => {
+    const t = convexTest(schema, modules);
+
+    const result = await t.action(api.unified.syncRoleAction, {
+      tenantId: TENANT,
+      role: "member",
+      rolePermissionsMap: { member: ["organizations:read"] },
+    });
+    expect(result.usersProcessed).toBe(0);
+  });
+});

--- a/src/component/unified.ts
+++ b/src/component/unified.ts
@@ -11,7 +11,9 @@
  */
 
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server.js";
+import { paginationOptsValidator } from "convex/server";
+import { action, mutation, query } from "./_generated/server.js";
+import { api } from "./_generated/api.js";
 import { scopeValidator } from "./validators.js";
 import { isExpired, matchesPermissionPattern } from "./helpers.js";
 
@@ -1857,3 +1859,116 @@ export const revokeAllRolesUnified = mutation({
     return revokedCount;
   },
 });
+
+/**
+ * List unique user IDs in a tenant who hold a given role.
+ *
+ * Helper for `syncRoleAction`. Pages over `roleAssignments` via the
+ * `by_tenant_role` index and dedupes within each page (a user can hold the
+ * same role in multiple scopes; we only need the userId once per recompute).
+ *
+ * Cross-page dedup is the caller's responsibility — a user split across pages
+ * by Convex's pagination cursor will appear in multiple batches.
+ */
+export const listUserIdsWithRole = query({
+  args: {
+    tenantId: v.string(),
+    role: v.string(),
+    paginationOpts: paginationOptsValidator,
+  },
+  returns: v.object({
+    userIds: v.array(v.string()),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_tenant_role", (q) =>
+        q.eq("tenantId", args.tenantId).eq("role", args.role),
+      )
+      .paginate(args.paginationOpts);
+
+    const uniqueUserIds = [...new Set(result.page.map((a) => a.userId))];
+
+    return {
+      userIds: uniqueUserIds,
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
+
+/**
+ * Sync Role
+ *
+ * Re-materialize `effectivePermissions` and `effectiveRoles` for every user
+ * who currently holds the given role, using the supplied permission map as
+ * the new role definition.
+ *
+ * Use case: a role definition in client code (`defineRoles(...)`) gained or
+ * lost permissions, the app redeployed, and existing assignments still carry
+ * the old materialized rows. `syncRoleAction` walks every assignment and
+ * calls `recomputeUser` per user.
+ *
+ * Behavior preserved across recompute:
+ *   - Direct grants (`directGrant: true` rows in `effectivePermissions`)
+ *   - Direct denies (`directDeny: true` rows in `effectivePermissions`)
+ *   These come from `permissionOverrides` and are intentionally untouched.
+ *
+ * Scale: each user is recomputed in its own mutation transaction. The action
+ * iterates through pages of 50 unique userIds at a time. For very large user
+ * bases, run the action multiple times or shard by tenant.
+ */
+export const syncRoleAction = action({
+  args: {
+    tenantId: v.string(),
+    role: v.string(),
+    rolePermissionsMap: v.record(v.string(), v.array(v.string())),
+    policyClassifications: v.optional(
+      v.record(
+        v.string(),
+        v.union(
+          v.null(),
+          v.literal("allow"),
+          v.literal("deny"),
+          v.literal("deferred"),
+        ),
+      ),
+    ),
+  },
+  returns: v.object({ usersProcessed: v.number() }),
+  handler: async (ctx, args) => {
+    let cursor: string | null = null;
+    const seen = new Set<string>();
+
+    while (true) {
+      const batch: {
+        userIds: string[];
+        isDone: boolean;
+        continueCursor: string;
+      } = await ctx.runQuery(api.unified.listUserIdsWithRole, {
+        tenantId: args.tenantId,
+        role: args.role,
+        paginationOpts: { numItems: 50, cursor },
+      });
+
+      for (const userId of batch.userIds) {
+        if (seen.has(userId)) continue;
+        seen.add(userId);
+        await ctx.runMutation(api.unified.recomputeUser, {
+          tenantId: args.tenantId,
+          userId,
+          rolePermissionsMap: args.rolePermissionsMap,
+          policyClassifications: args.policyClassifications,
+        });
+      }
+
+      if (batch.isDone) break;
+      cursor = batch.continueCursor;
+    }
+
+    return { usersProcessed: seen.size };
+  },
+});
+


### PR DESCRIPTION
Release `2.3.0`. Bundles two changes that have accumulated on `dev` since the `2.2.0` release.

## Changes

* **feat: add syncRole and syncRoles to propagate role-definition changes** (#34, closes #30) — re-materialize \`effectivePermissions\` for every user holding a given role when the role definition gains or loses permissions. New \`Authz.syncRole(ctx, role)\` and \`Authz.syncRoles(ctx)\` client methods, backed by a paginated \`syncRoleAction\` on the component side that calls \`recomputeUser\` per user. Direct grants and direct denies are preserved across recompute. 6 e2e regression tests + 4 client mock tests.
* **docs: document tag-pattern migration gotcha in PUBLISHING.md** — adds a "Configuration migration: changing the tag pattern" section. Documents why the bogus 2.3.0 release-please PR fired during the OIDC migration, the backfill recipe (\`git tag v2.2.0 \$(git rev-parse convex-authz-v2.2.0)\`), and the manual-close requirement for stale release PRs.

## Test plan

- [ ] \`Test and lint\` passes (669 tests including the new sync-roles regression suite)
- [ ] \`Validate PR title\` passes — \`feat:\` triggers the next minor bump
- [ ] After merge, release-please opens \`chore(main): release 2.3.0\` PR with both bullet points rendered in the CHANGELOG (\`### Features\` for syncRole, \`### Documentation\` for the gotcha)
- [ ] Merging the release PR triggers the OIDC publish job — **first end-to-end production test of Trusted Publishing**
- [ ] \`@djpanda/convex-authz@2.3.0\` lands on npm with provenance attestation chained to this commit
- [ ] After release ships, sync \`dev\` back to \`main\` (squash collapses these into one commit; \`dev\` will diverge by SHA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)