### PR TITLE
fix: throw ConvexError for permission denials

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -22,6 +22,7 @@
  * ```
  */
 
+import { ConvexError } from "convex/values";
 import type {
   GenericActionCtx,
   GenericDataModel,
@@ -596,9 +597,17 @@ export class Authz<
   ): Promise<void> {
     const allowed = await this.can(ctx, userId, permission, scope);
     if (!allowed) {
-      throw new Error(
-        `Permission denied: ${permission}${scope ? ` on ${scope.type}:${scope.id}` : ""}`
-      );
+      // ConvexError (not plain Error) so the rejection is classified as an
+      // expected, structured failure on the client side instead of an
+      // "Uncaught Error / Server Error" with internal stack trace exposed.
+      // Consumers can catch and pattern-match on `.data.code === "FORBIDDEN"`.
+      throw new ConvexError({
+        code: "FORBIDDEN",
+        message: `Permission denied: ${permission}${scope ? ` on ${scope.type}:${scope.id}` : ""}`,
+        permission: String(permission),
+        scopeType: scope?.type ?? null,
+        scopeId: scope?.id ?? null,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
Authz.require() now throws ConvexError instead of plain Error for permission denials. Convex classifies the rejection as a structured, expected error instead of an "Uncaught Error / Server Error" with internal stack traces visible to consumers.

Clients can now pattern-match on `error.data.code === "FORBIDDEN"` for typed handling:
```
{ code: "FORBIDDEN", message, permission, scopeType, scopeId }
```

## Backward compatibility
ConvexError preserves `.message`, so the 5 existing tests asserting `.rejects.toThrow("Permission denied: ...")` continue to pass without modification.

## Release
release-please will pick this up as a patch bump (2.3.0 → 2.3.1) on merge to main.

## Test plan
- [x] `npm run test` — 669/669 pass
- [x] `npm run typecheck` — clean
- [x] Verified end-to-end against a downstream consumer (`@djpanda/convex-tenants`) — permission denials now arrive at the client with structured `errorData` instead of opaque server-error stack traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)