### PR TITLE
feat: add permission override removal API

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,9 @@ await authz.grantPermission(ctx, userId, "documents:*", undefined, "Full documen
 
 // Deny read on any resource
 await authz.denyPermission(ctx, userId, "*:read", undefined, "Read access revoked");
+
+// Remove the direct override and fall back to role/policy-derived access
+await authz.removeOverride(ctx, userId, "*:read");
 ```
 
 **Role definitions:** When the component evaluates permissions, it matches the requested permission against each role’s permission list using the same pattern rules. So if a role’s permissions include `"documents:*"` (in the flattened role–permission map), then `can(ctx, userId, "documents:read")` is allowed. With `defineRoles` you typically list concrete actions per resource (e.g. `documents: ["read", "update"]`); to use patterns in roles you would supply a role-permission map that includes pattern strings for that role.
@@ -947,6 +950,16 @@ await authz.grantPermission(ctx, userId, "documents:delete", undefined, "Tempora
 await authz.denyPermission(ctx, userId, "documents:delete", undefined, "Access restricted");
 ```
 
+### Removing Permission Overrides
+
+```typescript
+// Remove a direct grant or deny and restore access from roles/policies
+await authz.removeOverride(ctx, userId, "documents:delete");
+
+// With scope
+await authz.removeOverride(ctx, userId, "documents:delete", { type: "team", id: "team_123" });
+```
+
 ---
 
 ## Schema Reference
@@ -1018,6 +1031,7 @@ class Authz<P, R, Policy> {
   // Permission overrides
   grantPermission(ctx, userId, permission, scope?, reason?, expiresAt?, actorId?): Promise<string>
   denyPermission(ctx, userId, permission, scope?, reason?, expiresAt?, actorId?): Promise<string>
+  removeOverride(ctx, userId, permission, scope?, actorId?): Promise<boolean>
   
   // Audit
   getAuditLog(ctx, options?): Promise<AuditEntry[] | { page: AuditEntry[]; isDone: boolean; continueCursor: string }>

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -577,6 +577,7 @@ describe("Authz class", () => {
         revokeAllRolesUnified: "unified.revokeAllRolesUnified",
         grantPermissionUnified: "unified.grantPermissionUnified",
         denyPermissionUnified: "unified.denyPermissionUnified",
+        removeOverrideUnified: "unified.removeOverrideUnified",
         addRelationUnified: "unified.addRelationUnified",
         removeRelationUnified: "unified.removeRelationUnified",
         recomputeUser: "unified.recomputeUser",
@@ -1671,6 +1672,62 @@ describe("Authz class", () => {
           objectId: "sales",
           tenantId: "test-tenant",
         }
+      );
+    });
+  });
+
+  describe("removeOverride", () => {
+    it("should remove permission override via unified.removeOverrideUnified", async () => {
+      const component = createMockComponent();
+      const authz = new Authz(component, { permissions, roles, tenantId: "test-tenant" });
+
+      const ctx = {
+        runMutation: vi.fn().mockResolvedValue(true),
+      };
+
+      const result = await authz.removeOverride(
+        ctx,
+        "user_123",
+        "documents:delete"
+      );
+
+      expect(result).toBe(true);
+      expect(ctx.runMutation).toHaveBeenCalledWith(
+        component.unified.removeOverrideUnified,
+        expect.objectContaining({
+          userId: "user_123",
+          permission: "documents:delete",
+          enableAudit: true,
+          tenantId: "test-tenant",
+        })
+      );
+    });
+
+    it("should pass scope and actorId", async () => {
+      const component = createMockComponent();
+      const authz = new Authz(component, { permissions, roles, tenantId: "test-tenant" });
+
+      const ctx = {
+        runMutation: vi.fn().mockResolvedValue(true),
+      };
+
+      const scope = { type: "doc", id: "doc_1" };
+      await authz.removeOverride(
+        ctx,
+        "user_123",
+        "documents:delete",
+        scope,
+        "actor_1"
+      );
+
+      expect(ctx.runMutation).toHaveBeenCalledWith(
+        component.unified.removeOverrideUnified,
+        expect.objectContaining({
+          scope,
+          removedBy: "actor_1",
+          tenantId: "test-tenant",
+          rolePermissionsMap: expect.any(Object),
+        })
       );
     });
   });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1043,6 +1043,32 @@ export class Authz<
   }
 
   /**
+   * Remove a direct permission override and restore role/policy-derived access.
+   * Returns false when no matching override exists.
+   */
+  async removeOverride(
+    ctx: MutationCtx | ActionCtx,
+    userId: string,
+    permission: PermissionArg<P>,
+    scope?: Scope,
+    actorId?: string
+  ): Promise<boolean> {
+    validateUserId(userId);
+    validatePermission(permission);
+    validateScope(scope);
+    return await ctx.runMutation(this.component.unified.removeOverrideUnified, {
+      tenantId: this.options.tenantId,
+      userId,
+      permission,
+      scope,
+      rolePermissionsMap: this.buildRolePermissionsMap(),
+      policyClassifications: this.buildPolicyClassifications(),
+      removedBy: actorId ?? this.options.defaultActorId,
+      enableAudit: true,
+    });
+  }
+
+  /**
    * Check relationship - O(1) indexed lookup
    */
   async hasRelation(
@@ -1271,6 +1297,7 @@ export class Authz<
         | "role_revoked"
         | "permission_granted"
         | "permission_denied"
+        | "permission_override_removed"
         | "attribute_set"
         | "attribute_removed"
         | "relation_added"

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -213,6 +213,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             | "role_revoked"
             | "permission_granted"
             | "permission_denied"
+            | "permission_override_removed"
             | "attribute_set"
             | "attribute_removed"
             | "relation_added"
@@ -553,6 +554,25 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           userId: string;
         },
         null,
+        Name
+      >;
+      removeOverrideUnified: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          enableAudit?: boolean;
+          permission: string;
+          policyClassifications?: Record<
+            string,
+            null | "allow" | "deny" | "deferred"
+          >;
+          removedBy?: string;
+          rolePermissionsMap: Record<string, Array<string>>;
+          scope?: { id: string; type: string };
+          tenantId: string;
+          userId: string;
+        },
+        boolean,
         Name
       >;
       removeRelationUnified: FunctionReference<

--- a/src/component/queries.ts
+++ b/src/component/queries.ts
@@ -246,6 +246,7 @@ const auditLogActionValidator = v.union(
   v.literal("role_revoked"),
   v.literal("permission_granted"),
   v.literal("permission_denied"),
+  v.literal("permission_override_removed"),
   v.literal("attribute_set"),
   v.literal("attribute_removed"),
   v.literal("relation_added"),
@@ -323,6 +324,7 @@ export const getAuditLog = query({
                 | "role_revoked"
                 | "permission_granted"
                 | "permission_denied"
+                | "permission_override_removed"
                 | "attribute_set"
                 | "attribute_removed"
                 | "relation_added"

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -164,6 +164,7 @@ export default defineSchema({
       v.literal("role_revoked"),
       v.literal("permission_granted"),
       v.literal("permission_denied"),
+      v.literal("permission_override_removed"),
       v.literal("attribute_set"),
       v.literal("attribute_removed"),
       v.literal("relation_added"),

--- a/src/component/tests/mutations.test.ts
+++ b/src/component/tests/mutations.test.ts
@@ -1046,6 +1046,235 @@ describe("mutations - additional coverage", () => {
     });
   });
 
+  describe("removeOverride", () => {
+    it("should remove a direct override and delete effective permission with no remaining sources", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.unified.grantPermissionUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        reason: "Temporary access",
+      });
+
+      const result = await t.mutation(api.unified.removeOverrideUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        rolePermissionsMap: {},
+        removedBy: "actor_1",
+        enableAudit: true,
+      });
+
+      expect(result).toBe(true);
+
+      const overrides = await t.query(api.queries.getPermissionOverrides, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+      expect(overrides).toHaveLength(0);
+
+      const check = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+      expect(check.allowed).toBe(false);
+
+      const logsResult = await t.query(api.queries.getAuditLog, {
+        tenantId: TENANT,
+        userId: "user_123",
+      });
+      const logs = Array.isArray(logsResult) ? logsResult : logsResult.page;
+      expect(logs.some((l) => l.action === "permission_override_removed")).toBe(true);
+    });
+
+    it("should restore role-derived allow after removing a deny override", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.unified.assignRoleUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        role: "editor",
+        rolePermissions: ["documents:delete"],
+      });
+
+      await t.mutation(api.unified.denyPermissionUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        reason: "Temporary block",
+      });
+
+      let check = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+      expect(check.allowed).toBe(false);
+
+      const result = await t.mutation(api.unified.removeOverrideUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        rolePermissionsMap: {
+          editor: ["documents:delete"],
+        },
+      });
+
+      expect(result).toBe(true);
+
+      check = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+      expect(check.allowed).toBe(true);
+
+      const effectivePerms = await t.run(async (ctx) =>
+        await ctx.db.query("effectivePermissions").collect()
+      );
+      const restored = effectivePerms.find(
+        (perm) =>
+          perm.userId === "user_123" &&
+          perm.permission === "documents:delete" &&
+          perm.scopeKey === "global"
+      );
+
+      expect(restored).toBeDefined();
+      expect(restored?.effect).toBe("allow");
+      expect(restored?.sources).toEqual(["editor"]);
+      expect(restored?.directDeny).toBeUndefined();
+      expect(restored?.directGrant).toBeUndefined();
+      expect(restored?.reason).toBeUndefined();
+    });
+
+    it("should restore role expiration after removing a grant override", async () => {
+      const t = convexTest(schema, modules);
+      const expiresAt = Date.now() + 3600000;
+
+      await t.mutation(api.unified.assignRoleUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        role: "editor",
+        rolePermissions: ["documents:delete"],
+        expiresAt,
+      });
+
+      await t.mutation(api.unified.grantPermissionUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+
+      await t.mutation(api.unified.removeOverrideUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        rolePermissionsMap: {
+          editor: ["documents:delete"],
+        },
+      });
+
+      const effectivePerms = await t.run(async (ctx) =>
+        await ctx.db.query("effectivePermissions").collect()
+      );
+      const restored = effectivePerms.find(
+        (perm) => perm.userId === "user_123" && perm.permission === "documents:delete"
+      );
+
+      expect(restored?.expiresAt).toBe(expiresAt);
+    });
+
+    it("should restore deferred policy state after removing a grant override", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.unified.assignRoleUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        role: "editor",
+        rolePermissions: ["documents:delete"],
+        policyClassifications: {
+          "documents:delete": "deferred",
+        },
+      });
+
+      await t.mutation(api.unified.grantPermissionUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+
+      await t.mutation(api.unified.removeOverrideUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        rolePermissionsMap: {
+          editor: ["documents:delete"],
+        },
+        policyClassifications: {
+          "documents:delete": "deferred",
+        },
+      });
+
+      const check = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+
+      expect(check.allowed).toBe(true);
+      expect(check.tier).toBe("deferred");
+      expect(check.policyName).toBe("documents:delete");
+    });
+
+    it("should drop stale role sources that are no longer in the role permissions map", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.unified.assignRoleUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        role: "legacy_editor",
+        rolePermissions: ["documents:delete"],
+      });
+
+      await t.mutation(api.unified.denyPermissionUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+
+      await t.mutation(api.unified.removeOverrideUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        rolePermissionsMap: {},
+      });
+
+      const check = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+
+      expect(check.allowed).toBe(false);
+    });
+
+    it("should return false when no matching override exists", async () => {
+      const t = convexTest(schema, modules);
+
+      const result = await t.mutation(api.unified.removeOverrideUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        rolePermissionsMap: {},
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
 
 
   describe("cleanupExpired", () => {

--- a/src/component/unified.ts
+++ b/src/component/unified.ts
@@ -582,7 +582,7 @@ export const grantPermissionUnified = mutation({
           .eq("userId", args.userId)
           .eq("permission", args.permission)
       )
-      .take(100);
+      .take(4000);
 
     const existingOverride = existingOverrides.find((row) =>
       scopeEquals(row.scope, args.scope)
@@ -676,6 +676,177 @@ export const grantPermissionUnified = mutation({
 
     // 5. Return override ID
     return overrideId;
+  },
+});
+
+/**
+ * Remove a direct permission override.
+ *
+ * This deletes the source-of-truth override and clears directGrant/directDeny
+ * from the indexed effective permission. If the permission still has role or
+ * policy sources, the indexed row is restored to an allow from those sources;
+ * otherwise it is removed entirely.
+ */
+export const removeOverrideUnified = mutation({
+  args: {
+    tenantId: v.string(),
+    userId: v.string(),
+    permission: v.string(),
+    scope: scopeValidator,
+    rolePermissionsMap: v.record(v.string(), v.array(v.string())),
+    policyClassifications: v.optional(v.record(v.string(), v.union(
+      v.null(),
+      v.literal("allow"),
+      v.literal("deny"),
+      v.literal("deferred"),
+    ))),
+    removedBy: v.optional(v.string()),
+    enableAudit: v.optional(v.boolean()),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const scopeKey = args.scope
+      ? `${args.scope.type}:${args.scope.id}`
+      : "global";
+
+    const existingOverrides = await ctx.db
+      .query("permissionOverrides")
+      .withIndex("by_tenant_user_and_permission", (q) =>
+        q
+          .eq("tenantId", args.tenantId)
+          .eq("userId", args.userId)
+          .eq("permission", args.permission)
+      )
+      .take(100);
+
+    const existingOverride = existingOverrides.find((row) =>
+      scopeEquals(row.scope, args.scope)
+    );
+
+    if (!existingOverride) {
+      return false;
+    }
+
+    await ctx.db.delete(existingOverride._id);
+
+    const existingPerm = await ctx.db
+      .query("effectivePermissions")
+      .withIndex("by_tenant_user_permission_scope", (q) =>
+        q
+          .eq("tenantId", args.tenantId)
+          .eq("userId", args.userId)
+          .eq("permission", args.permission)
+          .eq("scopeKey", scopeKey)
+      )
+      .unique();
+
+    const roleAssignments = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_tenant_user", (q) =>
+        q.eq("tenantId", args.tenantId).eq("userId", args.userId)
+      )
+      .take(4000);
+
+    const nonRoleSources = existingPerm?.sources.filter((source) =>
+      source.startsWith("relation:")
+    ) ?? [];
+    const roleSources: string[] = [];
+    let roleExpiresAt: number | undefined | null = null;
+
+    for (const assignment of roleAssignments) {
+      if (!scopeEquals(assignment.scope, args.scope) || isExpired(assignment.expiresAt)) {
+        continue;
+      }
+
+      const permissions = args.rolePermissionsMap[assignment.role] ?? [];
+      const classification = args.policyClassifications?.[args.permission] ?? null;
+
+      if (!permissions.includes(args.permission) || classification === "deny") {
+        continue;
+      }
+
+      if (!roleSources.includes(assignment.role)) {
+        roleSources.push(assignment.role);
+      }
+
+      if (assignment.expiresAt === undefined) {
+        roleExpiresAt = undefined;
+      } else if (roleExpiresAt !== undefined) {
+        roleExpiresAt =
+          roleExpiresAt === null
+            ? assignment.expiresAt
+            : Math.max(roleExpiresAt, assignment.expiresAt);
+      }
+    }
+
+    const sources = [...nonRoleSources, ...roleSources];
+
+    if (sources.length > 0) {
+      const classification = args.policyClassifications?.[args.permission] ?? null;
+      const patchData: Record<string, unknown> = {
+        directGrant: undefined,
+        directDeny: undefined,
+        effect: "allow",
+        sources,
+        reason: undefined,
+        expiresAt: nonRoleSources.length > 0
+          ? existingPerm?.expiresAt
+          : roleExpiresAt === null
+            ? undefined
+            : roleExpiresAt,
+        policyResult: undefined,
+        policyName: undefined,
+        updatedAt: now,
+      };
+
+      if (classification === "deferred") {
+        patchData.policyResult = "deferred";
+        patchData.policyName = args.permission;
+      } else if (classification === "allow") {
+        patchData.policyResult = "allow";
+      }
+
+      if (existingPerm) {
+        await ctx.db.patch(existingPerm._id, {
+          ...patchData,
+        });
+      } else {
+        await ctx.db.insert("effectivePermissions", {
+          tenantId: args.tenantId,
+          userId: args.userId,
+          permission: args.permission,
+          scopeKey,
+          scope: args.scope,
+          effect: "allow",
+          sources,
+          expiresAt: patchData.expiresAt as number | undefined,
+          policyResult: patchData.policyResult as "allow" | "deferred" | undefined,
+          policyName: patchData.policyName as string | undefined,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    } else if (existingPerm) {
+      await ctx.db.delete(existingPerm._id);
+    }
+
+    if (args.enableAudit) {
+      await ctx.db.insert("auditLog", {
+        tenantId: args.tenantId,
+        timestamp: now,
+        action: "permission_override_removed",
+        userId: args.userId,
+        actorId: args.removedBy,
+        details: {
+          permission: args.permission,
+          scope: args.scope,
+          reason: `override_removed:${existingOverride.effect}`,
+        },
+      });
+    }
+
+    return true;
   },
 });
 
@@ -1973,4 +2144,3 @@ export const syncRoleAction = action({
     return { usersProcessed: seen.size };
   },
 });
-


### PR DESCRIPTION
## Summary

- add `Authz.removeOverride` and `removeOverrideUnified` for removing direct permission grant/deny overrides
- restore role-derived effective permissions after an override is removed, including role expiration and deferred policy metadata
- add audit log support for `permission_override_removed`
- document the new API and add regression coverage

## Testing

- `npm run build`
- `npm run typecheck`
- `npm run test`
- `npm run lint` (passes with existing warnings in example UI files and src/client/type-safety.test.ts)

## Notes

This is based on a downstream patch we needed for production role management: after temporarily granting or denying a permission directly, callers need a way to remove that override and fall back to the permissions derived from roles/policies.