### PR TITLE
feat: tenant-defined custom roles (closes #31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules
 coverage/
 .vercel
 .remember
+.playwright-mcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ One `Authz` class provides O(1) reads, ABAC policy support, and ReBAC — all in
 
 **Dual-layer design:** Source tables store ground truth; effective tables store pre-computed O(1) lookups. All writes go to BOTH layers via `unified.ts` mutations.
 
-- **Source tables**: `roleAssignments`, `userAttributes`, `permissionOverrides`, `relationships`, `auditLog`
+- **Source tables**: `roleAssignments`, `userAttributes`, `permissionOverrides`, `relationships`, `customRoles`, `auditLog`
 - **Effective tables**: `effectivePermissions`, `effectiveRoles`, `effectiveRelationships`
 
 **Permission check (`can()`) tiered resolution:**
@@ -53,15 +53,16 @@ Scope (`{ type: string; id: string }`) enables resource-level permissions. A rol
 
 ### Key File Map
 
-- `src/component/schema.ts` — 8 tables with all indexes
-- `src/component/unified.ts` — **v2 core**: tiered checkPermission query + dual-write mutations (assignRoleUnified, revokeRoleUnified, grantPermissionUnified, denyPermissionUnified, addRelationUnified, removeRelationUnified, setAttributeWithRecompute, recomputeUser)
+- `src/component/schema.ts` — 9 tables with all indexes
+- `src/component/unified.ts` — **v2 core**: tiered checkPermission query + dual-write mutations (assignRoleUnified, revokeRoleUnified, assignCustomRoleUnified, revokeCustomRoleUnified, grantPermissionUnified, denyPermissionUnified, addRelationUnified, removeRelationUnified, setAttributeWithRecompute, recomputeUser). Helpers `tryExtendExistingAssignment`, `writeNewAssignment`, `revokeAssignmentDualWrite` are private and shared by both system-role and custom-role mutation paths. `recomputeUser` resolves `custom:<id>` roles against `customRoles` automatically — callers don't need to pre-build a custom-role map.
+- `src/component/customRoles.ts` — **v2.4**: tenant-scoped custom role catalog (createCustomRole, updateCustomRoleDefinition + updateCustomRoleAction for cascade fan-out, deleteCustomRole, listCustomRoles, getCustomRole, getCustomRoleByName, getCustomRolePermissions, countCustomRoles). `customRoleStringFromId(id)` produces the namespaced `"custom:<id>"` string stored in roleAssignments.
 - `src/component/mutations.ts` — source-table mutations (offboardUser, deprovisionUser, cleanup, audit)
 - `src/component/queries.ts` — read queries (getUserRoles, hasRole, getUserAttributes, getAuditLog). `checkPermission`/`checkPermissions` are now internal.
 - `src/component/indexed.ts` — O(1) read queries (checkPermissionFast, hasRoleFast, hasRelationFast, getUserPermissionsFast, getUserRolesFast). Write mutations are now internal.
 - `src/component/rebac.ts` — relationship traversal (checkRelationWithTraversal, listAccessibleObjects, listUsersWithAccess)
 - `src/component/helpers.ts` — `matchesPermissionPattern`, scope matching, policy context
-- `src/client/index.ts` — unified `Authz` class + `definePermissions`, `defineRoles`, `definePolicies`, `defineTraversalRules`, `defineRelationPermissions`, `defineCaveats` helpers. `IndexedAuthz` is a deprecated alias.
-- `src/client/validation.ts` — input validation for client methods
+- `src/client/index.ts` — unified `Authz` class + `definePermissions`, `defineRoles`, `definePolicies`, `defineTraversalRules`, `defineRelationPermissions`, `defineCaveats` helpers. v2.4 adds `CustomRoleId` (branded `Id<"customRoles">`), `CustomRolesConfig<P>`, and 8 new methods on `Authz` (createCustomRole, updateCustomRole, deleteCustomRole, listCustomRoles, getCustomRole, getCustomRoleByName, assignCustomRole, revokeCustomRole). `IndexedAuthz` is a deprecated alias.
+- `src/client/validation.ts` — input validation for client methods (incl. validateCustomRoleId, validateCustomRoleName, validateGrantablePermissions, validateCustomRolePermissions)
 - `src/react/index.ts` — `AuthzProvider`, `useCanUser`, `useUserRoles`, `PermissionGate`
 
 ### Package Exports
@@ -78,6 +79,17 @@ Scope (`{ type: string; id: string }`) enables resource-level permissions. A rol
 
 Permission strings support patterns: `"*"` (all), `"resource:*"` (all actions on resource), `"*:action"` (action on all resources). Matching happens in `matchesPermissionPattern()`.
 
+### Custom Roles (v2.4, opt-in)
+
+Tenant admins can define their own role bundles at runtime, composed only from a SaaS-provider-supplied `grantablePermissions` whitelist. Storage convention: custom roles are stored in `customRoles` (tenant-scoped) and the role string in `roleAssignments`/`effectiveRoles` is the namespaced form `"custom:<id>"`. Read-path queries (`hasRoleFast`, `checkPermissionFast`) treat them identically to system roles — no branching, no extra reads on the hot path.
+
+**Three load-bearing decisions:**
+- **Composition only.** Tenant admins compose existing permissions; they never invent new strings. `grantablePermissions` is enforced at create/update time.
+- **Custom-role-from-system snapshot.** Custom role `permissions[]` is a snapshot at create time. Updating a system role definition does not auto-update custom roles built on it (prevents redeploy-breaks-tenant footgun).
+- **Custom-role-update cascade.** When a tenant admin edits a custom role, all assigned users are recomputed via `recomputeUser` (`updateCustomRoleAction`, mirrors `syncRoleAction`). No-op edits skip the fan-out.
+
+The feature is fully opt-in: omitting `customRoles` from the `Authz` constructor leaves the existing API surface and behavior untouched.
+
 ## Test Pattern
 
 Tests use `convex-test`:
@@ -92,7 +104,7 @@ await t.mutation(api.mutations.assignRole, { userId, role, ... });
 const result = await t.query(api.queries.hasRole, { userId, role, ... });
 ```
 
-Each test gets a fresh database. Test files: `authz.test.ts`, `queries.test.ts`, `indexed.test.ts`, `rebac.test.ts`, `scenarios.test.ts`, `helpers.test.ts`, `unified.test.ts`, `unified-e2e.test.ts`, `tenant-isolation.test.ts`, `client/index.test.ts`, `react/index.test.ts`.
+Each test gets a fresh database. Test files: `authz.test.ts`, `queries.test.ts`, `indexed.test.ts`, `rebac.test.ts`, `scenarios.test.ts`, `helpers.test.ts`, `unified.test.ts`, `unified-e2e.test.ts`, `tenant-isolation.test.ts`, `customRoles.test.ts`, `customRoleAssignment.test.ts`, `customRoleCascade.test.ts`, `issue-31-custom-roles.test.ts`, `client/index.test.ts`, `client/customRoles.test.ts`, `react/index.test.ts`.
 
 After creating new `.ts` files in `src/component/`, run `npm run build:codegen` to regenerate `_generated/api.ts`.
 

--- a/README.md
+++ b/README.md
@@ -519,6 +519,88 @@ const roles = await authz.getUserRoles(ctx, userId);
 // Returns: [{ role: "admin", scopeKey: "global" }, { role: "editor", scopeKey: "team:123", scope: { type: "team", id: "123" } }]
 ```
 
+### Custom roles (tenant-defined, opt-in)
+
+For B2B SaaS apps where tenant admins need to define their own role bundles
+(e.g. "Senior Editor", "Approver", "Outside Counsel"), enable the `customRoles`
+option on the `Authz` constructor. Tenants compose roles from a SaaS-provider-
+defined whitelist of permissions — they cannot invent new permission strings
+at runtime, which keeps the type-safety win above intact and prevents
+permission-escalation footguns.
+
+#### Configure the whitelist
+
+```typescript
+const authz = new Authz(components.authz, {
+  permissions,
+  roles,
+  tenantId: "tenant-acme",
+  customRoles: {
+    enabled: true,
+    grantablePermissions: [
+      "documents:read",
+      "documents:update",
+      "documents:delete",
+      "settings:view",
+    ] as const,                  // typed against PermissionArg<P> — typos rejected at compile time
+    maxRolesPerTenant: 50,        // optional, default 100
+  },
+});
+```
+
+#### Lifecycle
+
+```typescript
+// Tenant admin creates a custom role
+const roleId = await authz.createCustomRole(ctx, {
+  name: "Senior Editor",
+  permissions: ["documents:read", "documents:update"],
+  description: "Can edit but not delete",
+  createdBy: currentUserId,
+});
+
+// Assign / revoke (same shape as system roles, but with the branded id)
+await authz.assignCustomRole(ctx, userId, roleId);
+await authz.revokeCustomRole(ctx, userId, roleId);
+
+// Permission checks are unchanged — `can()` doesn't care where a permission came from
+const canEdit = await authz.can(ctx, userId, "documents:update");
+
+// Update propagates to every assigned user via recomputeUser
+const result = await authz.updateCustomRole(ctx, {
+  customRoleId: roleId,
+  permissions: ["documents:read", "documents:update", "documents:delete"],
+});
+// → { permissionsChanged: true, usersRecomputed: 17 }
+
+// List / lookup
+const page = await authz.listCustomRoles(ctx, { numItems: 50, cursor: null });
+const role = await authz.getCustomRole(ctx, roleId);
+const byName = await authz.getCustomRoleByName(ctx, "Senior Editor");
+
+// Delete (refuses if any user holds the role unless `force: true`)
+await authz.deleteCustomRole(ctx, { customRoleId: roleId, force: true });
+```
+
+#### Design decisions worth knowing
+
+- **Composition only, never new permissions.** Tenant admins compose existing
+  permissions; the whitelist enforced at create/update time is the security
+  boundary.
+- **Branded `CustomRoleId`.** Cannot be confused with system role names
+  (`keyof R`) or with raw strings at compile time.
+- **Snapshot semantics from system roles.** A custom role's `permissions[]`
+  is a snapshot at create time. If the SaaS provider later updates a system
+  role definition, custom roles built around the old set do not auto-update —
+  preventing surprise breakage on redeploy.
+- **Cascade on definition update.** When a tenant admin edits a custom role's
+  permissions, every user holding it is re-materialized via `recomputeUser`.
+  Direct grants and direct denies on each user are preserved.
+- **Permission-check hot path is unchanged.** `can()` reads `effectivePermissions`
+  identically — custom-role-derived rows are indistinguishable from system-role-
+  derived rows. Zero performance impact for permission checks regardless of
+  whether the feature is enabled.
+
 ---
 
 ## Bulk operations and offboarding

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as app from "../app.js";
 import type * as benchmarkReal from "../benchmarkReal.js";
 import type * as constants from "../constants.js";
 import type * as consumerTests from "../consumerTests.js";
+import type * as customRolesExample from "../customRolesExample.js";
 import type * as example from "../example.js";
 import type * as http from "../http.js";
 import type * as liveFeatureTest from "../liveFeatureTest.js";
@@ -28,6 +29,7 @@ declare const fullApi: ApiFromModules<{
   benchmarkReal: typeof benchmarkReal;
   constants: typeof constants;
   consumerTests: typeof consumerTests;
+  customRolesExample: typeof customRolesExample;
   example: typeof example;
   http: typeof http;
   liveFeatureTest: typeof liveFeatureTest;

--- a/example/convex/app.ts
+++ b/example/convex/app.ts
@@ -4,10 +4,16 @@
  * These functions provide data for the frontend dashboard.
  */
 
-import { mutation, query } from "./_generated/server.js";
+import { mutation, query, action } from "./_generated/server.js";
 import { components } from "./_generated/api.js";
-import { Authz, definePermissions, defineRoles } from "@djpanda/convex-authz";
+import {
+  Authz,
+  definePermissions,
+  defineRoles,
+  type CustomRoleId,
+} from "@djpanda/convex-authz";
 import { v } from "convex/values";
+import { paginationOptsValidator } from "convex/server";
 import { DEMO_ROLES } from "./constants.js";
 
 // Define permissions and roles
@@ -39,7 +45,30 @@ const roles = defineRoles(permissions, {
   },
 });
 
-const authz = new Authz(components.authz, { permissions, roles, tenantId: "example" });
+// Whitelist of permissions that tenant admins are allowed to compose into
+// custom roles. The SaaS provider owns this list — typing it `as const` makes
+// each entry participate in the PermissionArg<P> type, so typos are caught
+// at compile time. `documents:delete` is intentionally excluded to demonstrate
+// that tenant admins cannot escalate beyond what the provider permits.
+const CUSTOM_ROLE_GRANTABLE_PERMISSIONS = [
+  "documents:create",
+  "documents:read",
+  "documents:update",
+  "settings:view",
+  "users:invite",
+  "billing:view",
+] as const;
+
+const authz = new Authz(components.authz, {
+  permissions,
+  roles,
+  tenantId: "example",
+  customRoles: {
+    enabled: true,
+    grantablePermissions: CUSTOM_ROLE_GRANTABLE_PERMISSIONS,
+    maxRolesPerTenant: 50,
+  },
+});
 
 // ============================================================================
 // Queries
@@ -360,6 +389,155 @@ export const denyPermission = mutation({
       String(args.userId),
       args.permission as any,
       scope
+    );
+  },
+});
+
+// ============================================================================
+// Custom Roles (issue #31) — tenant admins compose roles at runtime
+// ============================================================================
+
+/** The whitelist exposed to the UI so it can render which permissions are grantable. */
+export const getCustomRoleGrantablePermissions = query({
+  args: {},
+  returns: v.array(v.string()),
+  handler: async () => {
+    return [...CUSTOM_ROLE_GRANTABLE_PERMISSIONS];
+  },
+});
+
+export const listCustomRoles = query({
+  args: {},
+  returns: v.array(
+    v.object({
+      _id: v.string(),
+      name: v.string(),
+      description: v.optional(v.string()),
+      permissions: v.array(v.string()),
+      createdBy: v.string(),
+      createdAt: v.number(),
+      updatedAt: v.number(),
+    }),
+  ),
+  handler: async (ctx) => {
+    const result = await authz.listCustomRoles(ctx, {
+      numItems: 100,
+      cursor: null,
+    });
+    return result.page.map((r) => ({
+      _id: r._id,
+      name: r.name,
+      description: r.description,
+      permissions: r.permissions,
+      createdBy: r.createdBy,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+    }));
+  },
+});
+
+export const createCustomRole = mutation({
+  args: {
+    name: v.string(),
+    permissions: v.array(v.string()),
+    description: v.optional(v.string()),
+    createdBy: v.id("users"),
+  },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    return await authz.createCustomRole(ctx, {
+      name: args.name,
+      permissions: args.permissions as Array<
+        (typeof CUSTOM_ROLE_GRANTABLE_PERMISSIONS)[number]
+      >,
+      description: args.description,
+      createdBy: String(args.createdBy),
+    });
+  },
+});
+
+export const updateCustomRole = action({
+  args: {
+    customRoleId: v.string(),
+    name: v.optional(v.string()),
+    permissions: v.optional(v.array(v.string())),
+    description: v.optional(v.string()),
+    actorId: v.optional(v.id("users")),
+  },
+  returns: v.object({
+    permissionsChanged: v.boolean(),
+    usersRecomputed: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    return await authz.updateCustomRole(ctx, {
+      customRoleId: args.customRoleId as CustomRoleId,
+      name: args.name,
+      permissions: args.permissions as
+        | Array<(typeof CUSTOM_ROLE_GRANTABLE_PERMISSIONS)[number]>
+        | undefined,
+      description: args.description,
+      actorId: args.actorId ? String(args.actorId) : undefined,
+    });
+  },
+});
+
+export const deleteCustomRole = mutation({
+  args: {
+    customRoleId: v.string(),
+    force: v.optional(v.boolean()),
+  },
+  returns: v.object({
+    deleted: v.boolean(),
+    assignmentsRevoked: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const result = await authz.deleteCustomRole(ctx, {
+      customRoleId: args.customRoleId as CustomRoleId,
+      force: args.force,
+    });
+    return {
+      deleted: result.deleted,
+      assignmentsRevoked: result.assignmentsRevoked,
+    };
+  },
+});
+
+export const assignCustomRole = mutation({
+  args: {
+    userId: v.id("users"),
+    customRoleId: v.string(),
+    orgId: v.optional(v.id("orgs")),
+  },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    const scope = args.orgId
+      ? { type: "org", id: String(args.orgId) }
+      : undefined;
+    return await authz.assignCustomRole(
+      ctx,
+      String(args.userId),
+      args.customRoleId as CustomRoleId,
+      scope,
+    );
+  },
+});
+
+export const revokeCustomRole = mutation({
+  args: {
+    userId: v.id("users"),
+    customRoleId: v.string(),
+    orgId: v.optional(v.id("orgs")),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const scope = args.orgId
+      ? { type: "org", id: String(args.orgId) }
+      : undefined;
+    return await authz.revokeCustomRole(
+      ctx,
+      String(args.userId),
+      args.customRoleId as CustomRoleId,
+      scope,
     );
   },
 });

--- a/example/convex/customRolesExample.ts
+++ b/example/convex/customRolesExample.ts
@@ -1,0 +1,236 @@
+/**
+ * Example: tenant-admin-defined custom roles (issue #31)
+ *
+ * Demonstrates the full custom-roles flow:
+ *   - SaaS provider configures a `grantablePermissions` whitelist
+ *   - Tenant admin creates a custom role from that whitelist
+ *   - Users get assigned the custom role
+ *   - Permission checks use the same `can()` API
+ *   - Tenant admin updates the role; all assigned users are re-materialized
+ *   - Tenant admin deletes the role
+ *
+ * Run after `npm run build:codegen` so the customRoles component module is
+ * registered in the example app.
+ */
+
+import { mutation, query, action } from "./_generated/server.js";
+import { components } from "./_generated/api.js";
+import {
+  Authz,
+  definePermissions,
+  defineRoles,
+  type CustomRoleId,
+} from "@djpanda/convex-authz";
+import { v } from "convex/values";
+
+// ──────────────────────────────────────────────────────────────────────────
+// SaaS provider config: define permissions, system roles, and the whitelist
+// ──────────────────────────────────────────────────────────────────────────
+
+const permissions = definePermissions({
+  documents: { create: true, read: true, update: true, delete: true },
+  settings: { view: true, manage: true },
+});
+
+const systemRoles = defineRoles(permissions, {
+  admin: {
+    documents: ["create", "read", "update", "delete"],
+    settings: ["view", "manage"],
+  },
+  viewer: { documents: ["read"] },
+});
+
+/**
+ * The whitelist below is the security boundary: tenant admins can compose
+ * any subset of these into a custom role, but they cannot introduce
+ * permission strings outside this list. The `as const` keeps the entries
+ * typed as `PermissionArg<P>` so typos like "documets:read" fail to
+ * compile.
+ */
+const GRANTABLE_PERMISSIONS = [
+  "documents:read",
+  "documents:update",
+  "documents:create",
+  "settings:view",
+] as const;
+
+function makeAuthz(tenantId: string) {
+  return new Authz(components.authz, {
+    permissions,
+    roles: systemRoles,
+    tenantId,
+    customRoles: {
+      enabled: true,
+      grantablePermissions: GRANTABLE_PERMISSIONS,
+      maxRolesPerTenant: 50,
+    },
+  });
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// 1. Tenant admin creates a custom role
+// ──────────────────────────────────────────────────────────────────────────
+
+export const createSeniorEditorRole = mutation({
+  args: {
+    tenantId: v.string(),
+    actorId: v.string(),
+  },
+  returns: v.object({ customRoleId: v.string() }),
+  handler: async (ctx, args) => {
+    const authz = makeAuthz(args.tenantId);
+    const roleId = await authz.createCustomRole(ctx, {
+      name: "Senior Editor",
+      permissions: ["documents:read", "documents:update"],
+      description: "Can edit but not delete or create documents",
+      createdBy: args.actorId,
+    });
+    return { customRoleId: roleId };
+  },
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// 2. Assign and revoke
+// ──────────────────────────────────────────────────────────────────────────
+
+export const assignSeniorEditor = mutation({
+  args: {
+    tenantId: v.string(),
+    userId: v.string(),
+    customRoleId: v.string(),
+    actorId: v.string(),
+  },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    const authz = makeAuthz(args.tenantId);
+    return await authz.assignCustomRole(
+      ctx,
+      args.userId,
+      args.customRoleId as CustomRoleId,
+      undefined,
+      undefined,
+      args.actorId,
+    );
+  },
+});
+
+export const revokeSeniorEditor = mutation({
+  args: {
+    tenantId: v.string(),
+    userId: v.string(),
+    customRoleId: v.string(),
+    actorId: v.string(),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const authz = makeAuthz(args.tenantId);
+    return await authz.revokeCustomRole(
+      ctx,
+      args.userId,
+      args.customRoleId as CustomRoleId,
+      undefined,
+      args.actorId,
+    );
+  },
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// 3. Permission check — identical to system-role checks
+// ──────────────────────────────────────────────────────────────────────────
+
+export const canEditDocument = query({
+  args: { tenantId: v.string(), userId: v.string() },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const authz = makeAuthz(args.tenantId);
+    // can() doesn't care whether the permission came from a system role,
+    // a custom role, or a direct grant — it reads effectivePermissions.
+    return await authz.can(ctx, args.userId, "documents:update");
+  },
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// 4. Update (cascades to all assigned users via recomputeUser)
+// ──────────────────────────────────────────────────────────────────────────
+
+export const promoteSeniorEditorToCreator = action({
+  args: {
+    tenantId: v.string(),
+    customRoleId: v.string(),
+    actorId: v.string(),
+  },
+  returns: v.object({
+    permissionsChanged: v.boolean(),
+    usersRecomputed: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const authz = makeAuthz(args.tenantId);
+    return await authz.updateCustomRole(ctx, {
+      customRoleId: args.customRoleId as CustomRoleId,
+      permissions: [
+        "documents:read",
+        "documents:update",
+        "documents:create",
+      ],
+      actorId: args.actorId,
+    });
+  },
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// 5. List + lookup
+// ──────────────────────────────────────────────────────────────────────────
+
+export const listTenantCustomRoles = query({
+  args: { tenantId: v.string() },
+  returns: v.array(
+    v.object({
+      _id: v.string(),
+      name: v.string(),
+      permissions: v.array(v.string()),
+      description: v.optional(v.string()),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const authz = makeAuthz(args.tenantId);
+    const result = await authz.listCustomRoles(ctx, {
+      numItems: 100,
+      cursor: null,
+    });
+    return result.page.map((r) => ({
+      _id: r._id,
+      name: r.name,
+      permissions: r.permissions,
+      description: r.description,
+    }));
+  },
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// 6. Delete (force: true revokes all assignments first)
+// ──────────────────────────────────────────────────────────────────────────
+
+export const deleteCustomRole = mutation({
+  args: {
+    tenantId: v.string(),
+    customRoleId: v.string(),
+    force: v.optional(v.boolean()),
+    actorId: v.string(),
+  },
+  returns: v.object({
+    deleted: v.boolean(),
+    assignmentsRevoked: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const authz = makeAuthz(args.tenantId);
+    const result = await authz.deleteCustomRole(ctx, {
+      customRoleId: args.customRoleId as CustomRoleId,
+      force: args.force,
+      actorId: args.actorId,
+    });
+    return {
+      deleted: result.deleted,
+      assignmentsRevoked: result.assignmentsRevoked,
+    };
+  },
+});

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,8 +3,9 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { DashboardPage } from "@/pages/dashboard";
 import { UsersPage } from "@/pages/users";
 import { PermissionTesterPage } from "@/pages/permission-tester";
+import { CustomRolesPage } from "@/pages/custom-roles";
 
-type Page = "dashboard" | "users" | "permission-tester";
+type Page = "dashboard" | "users" | "custom-roles" | "permission-tester";
 
 function App() {
   const [currentPage, setCurrentPage] = useState<Page>("dashboard");
@@ -15,6 +16,8 @@ function App() {
         return <DashboardPage />;
       case "users":
         return <UsersPage />;
+      case "custom-roles":
+        return <CustomRolesPage />;
       case "permission-tester":
         return <PermissionTesterPage />;
       default:

--- a/example/src/components/app-sidebar.tsx
+++ b/example/src/components/app-sidebar.tsx
@@ -1,6 +1,7 @@
 import {
   LayoutDashboard,
   Users,
+  Sparkles,
   TestTube,
   Shield,
   Moon,
@@ -19,6 +20,7 @@ interface NavItem {
 const navItems: NavItem[] = [
   { title: "Dashboard", icon: LayoutDashboard, page: "dashboard" },
   { title: "Users & Roles", icon: Users, page: "users" },
+  { title: "Custom Roles", icon: Sparkles, page: "custom-roles" },
   { title: "Permission Tester", icon: TestTube, page: "permission-tester" },
 ];
 

--- a/example/src/pages/custom-roles.tsx
+++ b/example/src/pages/custom-roles.tsx
@@ -1,0 +1,432 @@
+import { useState } from "react";
+import { useQuery, useMutation, useAction } from "convex/react";
+import { api } from "@convex/_generated/api";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Sparkles,
+  Plus,
+  Trash2,
+  RefreshCw,
+  UserPlus,
+  AlertTriangle,
+} from "lucide-react";
+import type { Id } from "@convex/_generated/dataModel";
+
+interface CustomRoleDoc {
+  _id: string;
+  name: string;
+  description?: string;
+  permissions: string[];
+  createdBy: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export function CustomRolesPage() {
+  const users = useQuery(api.app.listUsers) ?? [];
+  const customRoles = (useQuery(api.app.listCustomRoles) ?? []) as CustomRoleDoc[];
+  const grantable =
+    (useQuery(api.app.getCustomRoleGrantablePermissions) ?? []) as string[];
+
+  const createCustomRole = useMutation(api.app.createCustomRole);
+  const deleteCustomRole = useMutation(api.app.deleteCustomRole);
+  const updateCustomRole = useAction(api.app.updateCustomRole);
+  const assignCustomRole = useMutation(api.app.assignCustomRole);
+
+  const [newName, setNewName] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+  const [newPermissions, setNewPermissions] = useState<Set<string>>(new Set());
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const [selectedRoleId, setSelectedRoleId] = useState<string | null>(null);
+  const [editPermissions, setEditPermissions] = useState<Set<string>>(new Set());
+  const [updating, setUpdating] = useState(false);
+  const [lastUpdateResult, setLastUpdateResult] = useState<{
+    permissionsChanged: boolean;
+    usersRecomputed: number;
+  } | null>(null);
+
+  const [assignUserId, setAssignUserId] = useState<Id<"users"> | "">("");
+  const [assignError, setAssignError] = useState<string | null>(null);
+
+  const togglePerm = (set: Set<string>, perm: string): Set<string> => {
+    const next = new Set(set);
+    if (next.has(perm)) next.delete(perm);
+    else next.add(perm);
+    return next;
+  };
+
+  const selectedRole = customRoles.find((r) => r._id === selectedRoleId);
+
+  const handleCreate = async () => {
+    setCreateError(null);
+    if (!newName.trim()) {
+      setCreateError("Name is required");
+      return;
+    }
+    if (newPermissions.size === 0) {
+      setCreateError("Pick at least one permission");
+      return;
+    }
+    if (users.length === 0) {
+      setCreateError("Seed users first (Dashboard → Seed Demo Data)");
+      return;
+    }
+    try {
+      setCreating(true);
+      await createCustomRole({
+        name: newName.trim(),
+        description: newDescription.trim() || undefined,
+        permissions: [...newPermissions],
+        createdBy: users[0]._id,
+      });
+      setNewName("");
+      setNewDescription("");
+      setNewPermissions(new Set());
+    } catch (err) {
+      setCreateError((err as Error).message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleSelectForEdit = (role: CustomRoleDoc) => {
+    setSelectedRoleId(role._id);
+    setEditPermissions(new Set(role.permissions));
+    setLastUpdateResult(null);
+  };
+
+  const handleApplyUpdate = async () => {
+    if (!selectedRole) return;
+    try {
+      setUpdating(true);
+      const result = await updateCustomRole({
+        customRoleId: selectedRole._id,
+        permissions: [...editPermissions],
+      });
+      setLastUpdateResult(result);
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  const handleAssign = async () => {
+    setAssignError(null);
+    if (!selectedRole || !assignUserId) {
+      setAssignError("Pick a user");
+      return;
+    }
+    try {
+      await assignCustomRole({
+        userId: assignUserId,
+        customRoleId: selectedRole._id,
+      });
+    } catch (err) {
+      setAssignError((err as Error).message);
+    }
+  };
+
+  const handleDelete = async (roleId: string, force: boolean) => {
+    try {
+      await deleteCustomRole({ customRoleId: roleId, force });
+      if (selectedRoleId === roleId) {
+        setSelectedRoleId(null);
+        setEditPermissions(new Set());
+      }
+    } catch (err) {
+      alert((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="space-y-6" data-testid="custom-roles-page">
+      <div className="flex items-center gap-2">
+        <Sparkles className="size-6" />
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Custom Roles</h1>
+          <p className="text-muted-foreground">
+            Tenant admins compose roles at runtime from a fixed permission whitelist
+          </p>
+        </div>
+      </div>
+
+      {/* Whitelist banner */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Grantable permissions</CardTitle>
+          <CardDescription>
+            The SaaS provider defines this whitelist. Tenant admins can compose
+            roles from these but cannot invent new permission strings.
+            <code className="ml-1 px-1 py-0.5 bg-muted rounded text-xs">
+              documents:delete
+            </code>{" "}
+            is intentionally excluded — try to assign it and watch it get
+            rejected.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-2" data-testid="grantable-list">
+            {grantable.map((p) => (
+              <Badge key={p} variant="secondary">
+                {p}
+              </Badge>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Create new */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Create a custom role</CardTitle>
+            <CardDescription>
+              Compose a role from the whitelist
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">
+                Name
+              </label>
+              <input
+                type="text"
+                className="w-full rounded border bg-background px-3 py-2 text-sm"
+                placeholder="e.g. Senior Editor"
+                value={newName}
+                data-testid="new-role-name"
+                onChange={(e) => setNewName(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">
+                Description (optional)
+              </label>
+              <input
+                type="text"
+                className="w-full rounded border bg-background px-3 py-2 text-sm"
+                placeholder="e.g. Can edit but not delete"
+                value={newDescription}
+                data-testid="new-role-description"
+                onChange={(e) => setNewDescription(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-2 block">
+                Permissions ({newPermissions.size})
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {grantable.map((p) => (
+                  <Button
+                    key={p}
+                    size="sm"
+                    variant={newPermissions.has(p) ? "default" : "outline"}
+                    onClick={() =>
+                      setNewPermissions((set) => togglePerm(set, p))
+                    }
+                    data-testid={`new-perm-${p}`}
+                  >
+                    {p}
+                  </Button>
+                ))}
+              </div>
+            </div>
+            {createError && (
+              <div
+                className="text-sm text-destructive flex items-center gap-2"
+                data-testid="create-error"
+              >
+                <AlertTriangle className="size-4" />
+                {createError}
+              </div>
+            )}
+            <Button
+              className="w-full"
+              onClick={handleCreate}
+              disabled={creating}
+              data-testid="create-role-button"
+            >
+              <Plus className="size-4 mr-2" />
+              {creating ? "Creating..." : "Create role"}
+            </Button>
+          </CardContent>
+        </Card>
+
+        {/* List */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              Roles defined for this tenant ({customRoles.length})
+            </CardTitle>
+            <CardDescription>
+              Pick one to edit or assign. Update propagates to all assigned
+              users via the cascade.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {customRoles.length === 0 ? (
+              <p
+                className="text-sm text-muted-foreground py-4 text-center"
+                data-testid="empty-roles"
+              >
+                No custom roles yet. Create one →
+              </p>
+            ) : (
+              <div className="space-y-2" data-testid="roles-list">
+                {customRoles.map((role) => (
+                  <div
+                    key={role._id}
+                    className={
+                      "border rounded-lg p-3 cursor-pointer transition " +
+                      (selectedRoleId === role._id
+                        ? "border-primary bg-accent"
+                        : "hover:bg-accent/50")
+                    }
+                    onClick={() => handleSelectForEdit(role)}
+                    data-testid={`role-row-${role.name}`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <div className="font-medium">{role.name}</div>
+                        {role.description && (
+                          <div className="text-xs text-muted-foreground">
+                            {role.description}
+                          </div>
+                        )}
+                        <div className="flex flex-wrap gap-1 mt-2">
+                          {role.permissions.map((p) => (
+                            <Badge
+                              key={p}
+                              variant="outline"
+                              className="text-xs"
+                            >
+                              {p}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                      <div className="flex gap-1">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="size-7"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void handleDelete(role._id, true);
+                          }}
+                          data-testid={`delete-role-${role.name}`}
+                        >
+                          <Trash2 className="size-3" />
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Edit selected role */}
+      {selectedRole && (
+        <Card data-testid="edit-card">
+          <CardHeader>
+            <CardTitle className="text-base">
+              Edit "{selectedRole.name}"
+            </CardTitle>
+            <CardDescription>
+              Toggle permissions and click "Apply update" — every user holding
+              this role is recomputed via{" "}
+              <code className="text-xs">recomputeUser</code>.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label className="text-xs text-muted-foreground mb-2 block">
+                Permissions ({editPermissions.size})
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {grantable.map((p) => (
+                  <Button
+                    key={p}
+                    size="sm"
+                    variant={editPermissions.has(p) ? "default" : "outline"}
+                    onClick={() =>
+                      setEditPermissions((set) => togglePerm(set, p))
+                    }
+                    data-testid={`edit-perm-${p}`}
+                  >
+                    {p}
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex gap-2">
+              <Button
+                onClick={handleApplyUpdate}
+                disabled={updating}
+                data-testid="apply-update-button"
+              >
+                <RefreshCw className="size-4 mr-2" />
+                {updating ? "Cascading..." : "Apply update"}
+              </Button>
+              {lastUpdateResult && (
+                <div
+                  className="flex items-center text-sm text-muted-foreground"
+                  data-testid="update-result"
+                >
+                  {lastUpdateResult.permissionsChanged
+                    ? `✓ ${lastUpdateResult.usersRecomputed} user(s) recomputed`
+                    : "✓ No-op (set unchanged)"}
+                </div>
+              )}
+            </div>
+
+            <div className="border-t pt-4">
+              <label className="text-xs text-muted-foreground mb-2 block">
+                Assign this role to a user
+              </label>
+              <div className="flex gap-2">
+                <select
+                  className="flex-1 rounded border bg-background px-3 py-2 text-sm"
+                  value={assignUserId}
+                  onChange={(e) =>
+                    setAssignUserId(e.target.value as Id<"users"> | "")
+                  }
+                  data-testid="assign-user-select"
+                >
+                  <option value="">— pick user —</option>
+                  {users.map((u) => (
+                    <option key={u._id} value={u._id}>
+                      {u.name}
+                    </option>
+                  ))}
+                </select>
+                <Button onClick={handleAssign} data-testid="assign-button">
+                  <UserPlus className="size-4 mr-2" />
+                  Assign
+                </Button>
+              </div>
+              {assignError && (
+                <div className="text-sm text-destructive mt-2">
+                  {assignError}
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/skills/convex-authz/SKILL.md
+++ b/skills/convex-authz/SKILL.md
@@ -543,6 +543,88 @@ const roles = await authz.getUserRoles(ctx, userId);
 // Returns: [{ role: "admin", scopeKey: "global" }, { role: "editor", scopeKey: "team:123", scope: { type: "team", id: "123" } }]
 ```
 
+### Custom roles (tenant-defined, opt-in)
+
+For B2B SaaS apps where tenant admins need to define their own role bundles
+(e.g. "Senior Editor", "Approver", "Outside Counsel"), enable the `customRoles`
+option on the `Authz` constructor. Tenants compose roles from a SaaS-provider-
+defined whitelist of permissions — they cannot invent new permission strings
+at runtime, which keeps the type-safety win above intact and prevents
+permission-escalation footguns.
+
+#### Configure the whitelist
+
+```typescript
+const authz = new Authz(components.authz, {
+  permissions,
+  roles,
+  tenantId: "tenant-acme",
+  customRoles: {
+    enabled: true,
+    grantablePermissions: [
+      "documents:read",
+      "documents:update",
+      "documents:delete",
+      "settings:view",
+    ] as const,                  // typed against PermissionArg<P> — typos rejected at compile time
+    maxRolesPerTenant: 50,        // optional, default 100
+  },
+});
+```
+
+#### Lifecycle
+
+```typescript
+// Tenant admin creates a custom role
+const roleId = await authz.createCustomRole(ctx, {
+  name: "Senior Editor",
+  permissions: ["documents:read", "documents:update"],
+  description: "Can edit but not delete",
+  createdBy: currentUserId,
+});
+
+// Assign / revoke (same shape as system roles, but with the branded id)
+await authz.assignCustomRole(ctx, userId, roleId);
+await authz.revokeCustomRole(ctx, userId, roleId);
+
+// Permission checks are unchanged — `can()` doesn't care where a permission came from
+const canEdit = await authz.can(ctx, userId, "documents:update");
+
+// Update propagates to every assigned user via recomputeUser
+const result = await authz.updateCustomRole(ctx, {
+  customRoleId: roleId,
+  permissions: ["documents:read", "documents:update", "documents:delete"],
+});
+// → { permissionsChanged: true, usersRecomputed: 17 }
+
+// List / lookup
+const page = await authz.listCustomRoles(ctx, { numItems: 50, cursor: null });
+const role = await authz.getCustomRole(ctx, roleId);
+const byName = await authz.getCustomRoleByName(ctx, "Senior Editor");
+
+// Delete (refuses if any user holds the role unless `force: true`)
+await authz.deleteCustomRole(ctx, { customRoleId: roleId, force: true });
+```
+
+#### Design decisions worth knowing
+
+- **Composition only, never new permissions.** Tenant admins compose existing
+  permissions; the whitelist enforced at create/update time is the security
+  boundary.
+- **Branded `CustomRoleId`.** Cannot be confused with system role names
+  (`keyof R`) or with raw strings at compile time.
+- **Snapshot semantics from system roles.** A custom role's `permissions[]`
+  is a snapshot at create time. If the SaaS provider later updates a system
+  role definition, custom roles built around the old set do not auto-update —
+  preventing surprise breakage on redeploy.
+- **Cascade on definition update.** When a tenant admin edits a custom role's
+  permissions, every user holding it is re-materialized via `recomputeUser`.
+  Direct grants and direct denies on each user are preserved.
+- **Permission-check hot path is unchanged.** `can()` reads `effectivePermissions`
+  identically — custom-role-derived rows are indistinguishable from system-role-
+  derived rows. Zero performance impact for permission checks regardless of
+  whether the feature is enabled.
+
 ---
 
 ## Bulk operations and offboarding

--- a/src/client/customRoles.test.ts
+++ b/src/client/customRoles.test.ts
@@ -72,14 +72,14 @@ describe("Authz constructor: customRoles config", () => {
     ).toThrow(/grantablePermissions/i);
   });
 
-  it("works without the customRoles option (feature disabled)", () => {
+  it("works without the customRoles option (feature disabled)", async () => {
     const authz = new Authz(createMockComponent(), {
       permissions,
       roles,
       tenantId: "test-tenant",
     });
     // Methods should throw with a helpful message when called without the feature
-    expect(() =>
+    await expect(
       authz.createCustomRole({} as never, {
         name: "x",
         permissions: ["docs:read"],

--- a/src/client/customRoles.test.ts
+++ b/src/client/customRoles.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  Authz,
+  definePermissions,
+  defineRoles,
+  type CustomRoleId,
+} from "./index.js";
+import type { ComponentApi } from "../component/_generated/component.js";
+
+const permissions = definePermissions({
+  docs: { read: true, write: true, delete: true, archive: true },
+  billing: { read: true, manage: true },
+});
+const roles = defineRoles(permissions, {
+  admin: { docs: ["read", "write", "delete"], billing: ["read", "manage"] },
+  viewer: { docs: ["read"] },
+});
+
+const GRANTABLE = ["docs:read", "docs:write", "docs:archive"] as const;
+
+function createMockComponent() {
+  return {
+    queries: {},
+    mutations: {},
+    unified: {
+      assignRoleUnified: "unified.assignRoleUnified",
+      revokeRoleUnified: "unified.revokeRoleUnified",
+      assignCustomRoleUnified: "unified.assignCustomRoleUnified",
+      revokeCustomRoleUnified: "unified.revokeCustomRoleUnified",
+    },
+    customRoles: {
+      createCustomRole: "customRoles.createCustomRole",
+      updateCustomRoleAction: "customRoles.updateCustomRoleAction",
+      deleteCustomRole: "customRoles.deleteCustomRole",
+      listCustomRoles: "customRoles.listCustomRoles",
+      getCustomRole: "customRoles.getCustomRole",
+      getCustomRoleByName: "customRoles.getCustomRoleByName",
+    },
+  } as unknown as ComponentApi;
+}
+
+function makeAuthzWithCustomRoles() {
+  return new Authz(createMockComponent(), {
+    permissions,
+    roles,
+    tenantId: "test-tenant",
+    customRoles: {
+      enabled: true,
+      grantablePermissions: GRANTABLE,
+      maxRolesPerTenant: 50,
+    },
+  });
+}
+
+describe("Authz constructor: customRoles config", () => {
+  it("accepts a config with non-empty grantablePermissions", () => {
+    expect(() => makeAuthzWithCustomRoles()).not.toThrow();
+  });
+
+  it("rejects an enabled config with an empty whitelist", () => {
+    expect(
+      () =>
+        new Authz(createMockComponent(), {
+          permissions,
+          roles,
+          tenantId: "test-tenant",
+          customRoles: {
+            enabled: true,
+            grantablePermissions: [],
+          },
+        }),
+    ).toThrow(/grantablePermissions/i);
+  });
+
+  it("works without the customRoles option (feature disabled)", () => {
+    const authz = new Authz(createMockComponent(), {
+      permissions,
+      roles,
+      tenantId: "test-tenant",
+    });
+    // Methods should throw with a helpful message when called without the feature
+    expect(() =>
+      authz.createCustomRole({} as never, {
+        name: "x",
+        permissions: ["docs:read"],
+        createdBy: "admin",
+      }),
+    ).rejects.toThrow(/customRoles feature is not enabled/);
+  });
+});
+
+describe("Authz.createCustomRole", () => {
+  it("forwards args to the mutation with the configured whitelist", async () => {
+    const authz = makeAuthzWithCustomRoles();
+    const mockId = "k1234567890" as CustomRoleId;
+    const ctx = {
+      runMutation: vi.fn().mockResolvedValue(mockId),
+    };
+
+    const id = await authz.createCustomRole(ctx, {
+      name: "Senior Editor",
+      permissions: ["docs:read", "docs:write"],
+      description: "Can edit but not delete",
+      createdBy: "admin-1",
+    });
+
+    expect(id).toBe(mockId);
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      "customRoles.createCustomRole",
+      expect.objectContaining({
+        tenantId: "test-tenant",
+        name: "Senior Editor",
+        permissions: ["docs:read", "docs:write"],
+        description: "Can edit but not delete",
+        createdBy: "admin-1",
+        grantablePermissions: GRANTABLE,
+        maxRolesPerTenant: 50,
+        enableAudit: true,
+      }),
+    );
+  });
+
+  it("rejects permissions not in the whitelist client-side", async () => {
+    const authz = makeAuthzWithCustomRoles();
+    const ctx = { runMutation: vi.fn() };
+
+    await expect(
+      authz.createCustomRole(ctx, {
+        name: "Bad",
+        permissions: ["docs:delete"], // not in whitelist
+        createdBy: "admin",
+      }),
+    ).rejects.toThrow(/grantablePermissions/);
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty role names", async () => {
+    const authz = makeAuthzWithCustomRoles();
+    const ctx = { runMutation: vi.fn() };
+
+    await expect(
+      authz.createCustomRole(ctx, {
+        name: "   ",
+        permissions: ["docs:read"],
+        createdBy: "admin",
+      }),
+    ).rejects.toThrow();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+});
+
+describe("Authz.updateCustomRole", () => {
+  it("invokes the cascade action and returns its result", async () => {
+    const authz = makeAuthzWithCustomRoles();
+    const ctx = {
+      runMutation: vi.fn(),
+      runQuery: vi.fn(),
+      runAction: vi.fn().mockResolvedValue({
+        permissionsChanged: true,
+        usersRecomputed: 7,
+      }),
+    };
+
+    const result = await authz.updateCustomRole(ctx, {
+      customRoleId: "k1234" as CustomRoleId,
+      permissions: ["docs:read", "docs:write"],
+      actorId: "admin",
+    });
+
+    expect(result.permissionsChanged).toBe(true);
+    expect(result.usersRecomputed).toBe(7);
+    expect(ctx.runAction).toHaveBeenCalledWith(
+      "customRoles.updateCustomRoleAction",
+      expect.objectContaining({
+        customRoleId: "k1234",
+        tenantId: "test-tenant",
+        permissions: ["docs:read", "docs:write"],
+        grantablePermissions: GRANTABLE,
+      }),
+    );
+  });
+
+  it("rejects updates that introduce non-grantable permissions", async () => {
+    const authz = makeAuthzWithCustomRoles();
+    const ctx = {
+      runMutation: vi.fn(),
+      runQuery: vi.fn(),
+      runAction: vi.fn(),
+    };
+
+    await expect(
+      authz.updateCustomRole(ctx, {
+        customRoleId: "k1234" as CustomRoleId,
+        permissions: ["billing:manage"], // not in whitelist
+      }),
+    ).rejects.toThrow(/grantablePermissions/);
+    expect(ctx.runAction).not.toHaveBeenCalled();
+  });
+});
+
+describe("Authz.assignCustomRole / revokeCustomRole", () => {
+  it("assignCustomRole forwards to assignCustomRoleUnified", async () => {
+    const authz = makeAuthzWithCustomRoles();
+    const ctx = {
+      runMutation: vi.fn().mockResolvedValue("assignment_id_1"),
+    };
+    const result = await authz.assignCustomRole(
+      ctx,
+      "user-1",
+      "k1234" as CustomRoleId,
+      { type: "team", id: "team-7" },
+    );
+    expect(result).toBe("assignment_id_1");
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      "unified.assignCustomRoleUnified",
+      expect.objectContaining({
+        tenantId: "test-tenant",
+        userId: "user-1",
+        customRoleId: "k1234",
+        scope: { type: "team", id: "team-7" },
+        enableAudit: true,
+      }),
+    );
+  });
+
+  it("revokeCustomRole forwards to revokeCustomRoleUnified", async () => {
+    const authz = makeAuthzWithCustomRoles();
+    const ctx = {
+      runMutation: vi.fn().mockResolvedValue(true),
+    };
+    const result = await authz.revokeCustomRole(
+      ctx,
+      "user-1",
+      "k1234" as CustomRoleId,
+    );
+    expect(result).toBe(true);
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      "unified.revokeCustomRoleUnified",
+      expect.objectContaining({
+        tenantId: "test-tenant",
+        userId: "user-1",
+        customRoleId: "k1234",
+      }),
+    );
+  });
+});
+
+describe("Authz.deleteCustomRole / listCustomRoles / getCustomRole", () => {
+  it("deleteCustomRole forwards force flag", async () => {
+    const authz = makeAuthzWithCustomRoles();
+    const ctx = {
+      runMutation: vi.fn().mockResolvedValue({
+        deleted: true,
+        assignmentsRevoked: 3,
+        effectiveRolesRemoved: 3,
+        effectivePermissionsRemoved: 9,
+      }),
+    };
+    await authz.deleteCustomRole(ctx, {
+      customRoleId: "k1234" as CustomRoleId,
+      force: true,
+    });
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      "customRoles.deleteCustomRole",
+      expect.objectContaining({ force: true }),
+    );
+  });
+
+  it("listCustomRoles forwards pagination opts", async () => {
+    const authz = makeAuthzWithCustomRoles();
+    const ctx = {
+      runQuery: vi.fn().mockResolvedValue({
+        page: [],
+        isDone: true,
+        continueCursor: "",
+      }),
+    };
+    await authz.listCustomRoles(ctx, { numItems: 50, cursor: null });
+    expect(ctx.runQuery).toHaveBeenCalledWith(
+      "customRoles.listCustomRoles",
+      expect.objectContaining({
+        tenantId: "test-tenant",
+        paginationOpts: { numItems: 50, cursor: null },
+      }),
+    );
+  });
+
+  it("getCustomRole returns null when not found", async () => {
+    const authz = makeAuthzWithCustomRoles();
+    const ctx = {
+      runQuery: vi.fn().mockResolvedValue(null),
+    };
+    const result = await authz.getCustomRole(ctx, "k1234" as CustomRoleId);
+    expect(result).toBeNull();
+  });
+});

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -28,8 +28,10 @@ import type {
   GenericDataModel,
   GenericMutationCtx,
   GenericQueryCtx,
+  PaginationResult,
 } from "convex/server";
 import type { ComponentApi } from "../component/_generated/component.js";
+import type { Id } from "../component/_generated/dataModel.js";
 import {
   validateTenantId,
   validateUserId,
@@ -43,6 +45,10 @@ import {
   validatePermissions,
   validateRoleAssignItems,
   validateRoles,
+  validateCustomRoleId,
+  validateCustomRoleName,
+  validateGrantablePermissions,
+  validateCustomRolePermissions,
   type RoleAssignItem,
   type RoleScopeItem,
 } from "./validation.js";
@@ -192,6 +198,65 @@ export interface Scope {
   type: string;
   id: string;
 }
+
+// ============================================================================
+// Custom Roles (tenant-defined, optional opt-in)
+// ============================================================================
+
+/**
+ * Branded id for a tenant-defined custom role. Returned by `createCustomRole`
+ * and accepted by `assignCustomRole`/`revokeCustomRole`/etc. Cannot be confused
+ * with a system role name (which is `keyof R & string`) at compile time —
+ * passing a raw string where a `CustomRoleId` is expected is a TS error.
+ */
+export type CustomRoleId = Id<"customRoles">;
+
+/**
+ * Opt-in configuration for tenant-defined custom roles.
+ *
+ * - `enabled` — must be `true` to enable the feature
+ * - `grantablePermissions` — the SaaS-provider-defined whitelist of
+ *   permission strings that tenant admins are allowed to compose into
+ *   custom roles. Tenants can compose existing permissions; they cannot
+ *   invent new ones. Validated at create/update time.
+ * - `maxRolesPerTenant` — optional cap (default 100) on the number of
+ *   custom role definitions per tenant
+ *
+ * When omitted, the feature is disabled and no custom-role methods are
+ * usable. Existing methods (`assignRole`, `can`, etc.) are unchanged.
+ */
+export interface CustomRolesConfig<P extends PermissionDefinition> {
+  enabled: true;
+  grantablePermissions: ReadonlyArray<PermissionArg<P>>;
+  maxRolesPerTenant?: number;
+}
+
+/** Shape of a custom role row returned by listCustomRoles / getCustomRole. */
+export interface CustomRoleDoc {
+  _id: CustomRoleId;
+  _creationTime: number;
+  tenantId: string;
+  name: string;
+  permissions: string[];
+  description?: string;
+  createdBy: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Discriminated user-role entry. System roles carry a typed name; custom
+ * roles carry their branded id and human-readable name.
+ */
+export type UserRoleEntry<R extends RoleDefinition<PermissionDefinition>> =
+  | { source: "system"; role: keyof R & string; scope?: Scope; expiresAt?: number }
+  | {
+      source: "custom";
+      customRoleId: CustomRoleId;
+      name: string;
+      scope?: Scope;
+      expiresAt?: number;
+    };
 
 // ============================================================================
 // Helper Functions
@@ -446,9 +511,28 @@ export class Authz<
       tenantId: string;
       // v2:
       relationPermissions?: RelationPermissionMap;
+      // v2.4: opt-in tenant-defined custom roles
+      customRoles?: CustomRolesConfig<P>;
     }
   ) {
     validateTenantId(options.tenantId);
+    if (options.customRoles?.enabled) {
+      validateGrantablePermissions(options.customRoles.grantablePermissions);
+    }
+  }
+
+  /**
+   * Internal: throws if the customRoles feature is not enabled. All custom-
+   * role methods call this first so the failure mode is "feature not configured"
+   * rather than a confusing downstream error.
+   */
+  private requireCustomRolesEnabled(): CustomRolesConfig<P> {
+    if (!this.options.customRoles?.enabled) {
+      throw new Error(
+        "customRoles feature is not enabled. Pass `customRoles: { enabled: true, grantablePermissions: [...] }` to the Authz constructor.",
+      );
+    }
+    return this.options.customRoles;
   }
 
   withTenant(tenantId: string): Authz<P, R, Policy> {
@@ -768,6 +852,246 @@ export class Authz<
       revokedBy: actorId ?? this.options.defaultActorId,
       enableAudit: true,
     });
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Custom Roles (opt-in via `customRoles` constructor option)
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Create a tenant-defined custom role composed from the configured
+   * `grantablePermissions` whitelist. Returns the branded `CustomRoleId`.
+   *
+   * Throws if any requested permission is not in the whitelist, the tenant
+   * has reached `maxRolesPerTenant`, or a role with this name already
+   * exists in the tenant.
+   */
+  async createCustomRole(
+    ctx: MutationCtx | ActionCtx,
+    args: {
+      name: string;
+      permissions: ReadonlyArray<PermissionArg<P>>;
+      description?: string;
+      createdBy: string;
+    },
+  ): Promise<CustomRoleId> {
+    const config = this.requireCustomRolesEnabled();
+    validateCustomRoleName(args.name);
+    validateUserId(args.createdBy);
+    validateCustomRolePermissions(
+      args.permissions as readonly string[],
+      config.grantablePermissions as readonly string[],
+    );
+    const id = await ctx.runMutation(
+      this.component.customRoles.createCustomRole,
+      {
+        tenantId: this.options.tenantId,
+        name: args.name,
+        permissions: args.permissions as string[],
+        description: args.description,
+        createdBy: args.createdBy,
+        grantablePermissions: config.grantablePermissions as string[],
+        maxRolesPerTenant: config.maxRolesPerTenant,
+        enableAudit: true,
+      },
+    );
+    return id as CustomRoleId;
+  }
+
+  /**
+   * Update a custom role. If `permissions` changes, every user holding the
+   * role is re-materialized via `recomputeUser`. Returns whether the
+   * permission set actually changed and how many users were recomputed.
+   *
+   * No-op edits (set-equal permissions, name/description only) skip the
+   * fan-out entirely.
+   */
+  async updateCustomRole(
+    ctx: ActionCtx,
+    args: {
+      customRoleId: CustomRoleId;
+      name?: string;
+      permissions?: ReadonlyArray<PermissionArg<P>>;
+      description?: string;
+      actorId?: string;
+    },
+  ): Promise<{ permissionsChanged: boolean; usersRecomputed: number }> {
+    const config = this.requireCustomRolesEnabled();
+    validateCustomRoleId(args.customRoleId);
+    if (args.name !== undefined) validateCustomRoleName(args.name);
+    if (args.permissions !== undefined) {
+      validateCustomRolePermissions(
+        args.permissions as readonly string[],
+        config.grantablePermissions as readonly string[],
+      );
+    }
+    return await ctx.runAction(
+      this.component.customRoles.updateCustomRoleAction,
+      {
+        tenantId: this.options.tenantId,
+        customRoleId: args.customRoleId,
+        name: args.name,
+        permissions: args.permissions as string[] | undefined,
+        description: args.description,
+        grantablePermissions: config.grantablePermissions as string[],
+        rolePermissionsMap: this.buildRolePermissionsMap(),
+        actorId: args.actorId ?? this.options.defaultActorId,
+        enableAudit: true,
+      },
+    );
+  }
+
+  /**
+   * Delete a custom role. Refuses by default if any user currently holds
+   * the role; pass `force: true` to revoke all assignments and clean up
+   * the materialized rows transactionally.
+   */
+  async deleteCustomRole(
+    ctx: MutationCtx | ActionCtx,
+    args: {
+      customRoleId: CustomRoleId;
+      force?: boolean;
+      actorId?: string;
+    },
+  ): Promise<{
+    deleted: boolean;
+    assignmentsRevoked: number;
+    effectiveRolesRemoved: number;
+    effectivePermissionsRemoved: number;
+  }> {
+    this.requireCustomRolesEnabled();
+    validateCustomRoleId(args.customRoleId);
+    return await ctx.runMutation(
+      this.component.customRoles.deleteCustomRole,
+      {
+        tenantId: this.options.tenantId,
+        customRoleId: args.customRoleId,
+        force: args.force,
+        actorId: args.actorId ?? this.options.defaultActorId,
+        enableAudit: true,
+      },
+    );
+  }
+
+  /**
+   * List custom roles for the current tenant (paginated).
+   */
+  async listCustomRoles(
+    ctx: QueryCtx | ActionCtx,
+    paginationOpts: { numItems: number; cursor: string | null } = {
+      numItems: 100,
+      cursor: null,
+    },
+  ): Promise<PaginationResult<CustomRoleDoc>> {
+    this.requireCustomRolesEnabled();
+    const result = await ctx.runQuery(
+      this.component.customRoles.listCustomRoles,
+      {
+        tenantId: this.options.tenantId,
+        paginationOpts,
+      },
+    );
+    return result as PaginationResult<CustomRoleDoc>;
+  }
+
+  /**
+   * Fetch a single custom role by id. Returns null if it does not exist or
+   * belongs to a different tenant.
+   */
+  async getCustomRole(
+    ctx: QueryCtx | ActionCtx,
+    customRoleId: CustomRoleId,
+  ): Promise<CustomRoleDoc | null> {
+    this.requireCustomRolesEnabled();
+    validateCustomRoleId(customRoleId);
+    const row = await ctx.runQuery(
+      this.component.customRoles.getCustomRole,
+      {
+        tenantId: this.options.tenantId,
+        customRoleId,
+      },
+    );
+    return row as CustomRoleDoc | null;
+  }
+
+  /**
+   * Look up a custom role by its human-readable name within the current
+   * tenant.
+   */
+  async getCustomRoleByName(
+    ctx: QueryCtx | ActionCtx,
+    name: string,
+  ): Promise<CustomRoleDoc | null> {
+    this.requireCustomRolesEnabled();
+    validateCustomRoleName(name);
+    const row = await ctx.runQuery(
+      this.component.customRoles.getCustomRoleByName,
+      {
+        tenantId: this.options.tenantId,
+        name,
+      },
+    );
+    return row as CustomRoleDoc | null;
+  }
+
+  /**
+   * Assign a custom role to a user. Permissions are snapshotted from the
+   * customRoles row at assignment time; subsequent edits to the role
+   * propagate via `updateCustomRole`'s cascade.
+   */
+  async assignCustomRole(
+    ctx: MutationCtx | ActionCtx,
+    userId: string,
+    customRoleId: CustomRoleId,
+    scope?: Scope,
+    expiresAt?: number,
+    actorId?: string,
+  ): Promise<string> {
+    this.requireCustomRolesEnabled();
+    validateUserId(userId);
+    validateCustomRoleId(customRoleId);
+    validateScope(scope);
+    validateOptionalExpiresAt(expiresAt);
+    return await ctx.runMutation(
+      this.component.unified.assignCustomRoleUnified,
+      {
+        tenantId: this.options.tenantId,
+        userId,
+        customRoleId,
+        scope,
+        expiresAt,
+        assignedBy: actorId ?? this.options.defaultActorId,
+        enableAudit: true,
+      },
+    );
+  }
+
+  /**
+   * Revoke a custom role from a user. Idempotent — returns false if the
+   * user doesn't currently hold the role.
+   */
+  async revokeCustomRole(
+    ctx: MutationCtx | ActionCtx,
+    userId: string,
+    customRoleId: CustomRoleId,
+    scope?: Scope,
+    actorId?: string,
+  ): Promise<boolean> {
+    this.requireCustomRolesEnabled();
+    validateUserId(userId);
+    validateCustomRoleId(customRoleId);
+    validateScope(scope);
+    return await ctx.runMutation(
+      this.component.unified.revokeCustomRoleUnified,
+      {
+        tenantId: this.options.tenantId,
+        userId,
+        customRoleId,
+        scope,
+        revokedBy: actorId ?? this.options.defaultActorId,
+        enableAudit: true,
+      },
+    );
   }
 
   /**

--- a/src/client/type-safety.test.ts
+++ b/src/client/type-safety.test.ts
@@ -123,3 +123,118 @@ describe("Type-safe permission strings", () => {
     expect(true).toBe(true);
   });
 });
+
+// ============================================================================
+// Type-safety invariants for tenant-defined custom roles (issue #31)
+// ============================================================================
+
+describe("Custom roles: branded CustomRoleId cannot be confused with strings", () => {
+  test("CustomRoleId is structurally distinct from raw string", () => {
+    // Compile-time only — verifies that a raw string cannot be passed where
+    // CustomRoleId is expected without an explicit cast. Runtime branded
+    // types in TypeScript guard against accidental coercion.
+    type AssignArg = Parameters<
+      Authz<P, never, never>["assignCustomRole"]
+    >[2];
+
+    // Valid: explicit cast through the branded type (this is what
+    // createCustomRole returns).
+    const _valid: AssignArg = "k1234567890" as unknown as AssignArg;
+
+    // @ts-expect-error — raw string cannot satisfy the branded CustomRoleId
+    const _bad: AssignArg = "raw_string";
+    void _bad;
+
+    expect(true).toBe(true);
+  });
+
+  test("CustomRoleId from one tenant cannot be confused with system role names", () => {
+    // System role names are typed as `keyof R & string`. Custom role ids are
+    // typed as `Id<"customRoles">`. They are structurally disjoint at the
+    // type level, so the wrong one in the wrong slot is caught.
+    type TestAuthz = Authz<
+      P,
+      { admin: { documents: ["read"] }; viewer: { documents: ["read"] } }
+    >;
+
+    // assignRole takes a system role name (keyof R & string)
+    type AssignRoleArg = Parameters<TestAuthz["assignRole"]>[2];
+    const _validRole: AssignRoleArg = "admin";
+    // @ts-expect-error — random string isn't in the role definition
+    const _badRole: AssignRoleArg = "k1234";
+    void _badRole;
+
+    expect(true).toBe(true);
+  });
+});
+
+describe("Custom roles: grantablePermissions whitelist is type-checked", () => {
+  test("non-existent permission strings are rejected in grantablePermissions", () => {
+    // The customRoles config's grantablePermissions is typed as
+    // ReadonlyArray<PermissionArg<P>>, so typos in the whitelist itself
+    // are caught at compile time — the SaaS provider can't accidentally
+    // widen the security boundary by typo.
+    type Options = ConstructorParameters<typeof Authz<P, never, never>>[1];
+    type CustomRolesConfig = NonNullable<Options["customRoles"]>;
+    type Whitelist = CustomRolesConfig["grantablePermissions"];
+
+    // Valid: real permissions
+    const _ok: Whitelist = ["documents:read", "settings:view"];
+
+    // @ts-expect-error — typo: "documets" instead of "documents"
+    const _bad: Whitelist = ["documets:read"];
+    void _bad;
+
+    // @ts-expect-error — non-existent action
+    const _bad2: Whitelist = ["documents:fly"];
+    void _bad2;
+
+    expect(true).toBe(true);
+  });
+
+  test("createCustomRole permissions arg is constrained to PermissionArg<P>", () => {
+    type CreateArg = Parameters<
+      Authz<P, never, never>["createCustomRole"]
+    >[1];
+    type PermsField = CreateArg["permissions"];
+
+    // Valid: typed permission strings
+    const _ok: PermsField = ["documents:read"] as const;
+
+    // @ts-expect-error — typo
+    const _bad: PermsField = ["documets:read"] as const;
+    void _bad;
+
+    expect(true).toBe(true);
+  });
+});
+
+describe("Custom roles: existing permission/role typing is preserved", () => {
+  test("assignRole still rejects unknown system role names (issue #23 invariant)", () => {
+    // Critical regression check: adding the customRoles feature must not
+    // weaken the static type-safety win from issue #23 — `keyof R & string`
+    // is still the type of the `role` parameter for system-role assignment.
+    type TestAuthz = Authz<
+      P,
+      { admin: { documents: ["read"] }; viewer: { documents: ["read"] } }
+    >;
+    type AssignArg = Parameters<TestAuthz["assignRole"]>[2];
+    const _ok: AssignArg = "admin";
+    // @ts-expect-error — typo in role name
+    const _bad: AssignArg = "admni";
+    void _bad;
+
+    expect(true).toBe(true);
+  });
+
+  test("can() still rejects typo'd permissions (issue #23 invariant)", () => {
+    type TestAuthz = Authz<P, never, never>;
+    type CanArg = Parameters<TestAuthz["can"]>[2];
+    const _ok: CanArg = "documents:read";
+    // @ts-expect-error — typo
+    const _bad: CanArg = "documets:read";
+    void _bad;
+
+    expect(true).toBe(true);
+  });
+});

--- a/src/client/validation.ts
+++ b/src/client/validation.ts
@@ -246,6 +246,87 @@ export function validateRoleAssignItems(
 }
 
 /**
+ * Validate a custom role id (the branded string returned from createCustomRole).
+ * Convex Id values are non-empty strings; runtime ownership is validated server-side.
+ */
+export function validateCustomRoleId(customRoleId: string): void {
+  if (typeof customRoleId !== "string") {
+    throw new Error("customRoleId must be a string");
+  }
+  if (customRoleId.trim().length === 0) {
+    throw new Error("customRoleId must be a non-empty string");
+  }
+}
+
+/**
+ * Validate a custom role name: non-empty trimmed string, max 200 chars.
+ */
+export function validateCustomRoleName(name: string): void {
+  if (typeof name !== "string") {
+    throw new Error("custom role name must be a string");
+  }
+  if (name.trim().length === 0) {
+    throw new Error("custom role name must be a non-empty string");
+  }
+  if (name.length > 200) {
+    throw new Error("custom role name must not exceed 200 characters");
+  }
+}
+
+/**
+ * Validate the grantablePermissions whitelist on the client config: array of
+ * non-empty strings. The actual whitelist enforcement happens server-side at
+ * createCustomRole / updateCustomRoleAction time.
+ */
+export function validateGrantablePermissions(
+  grantablePermissions: readonly string[],
+): void {
+  if (!Array.isArray(grantablePermissions)) {
+    throw new Error("customRoles.grantablePermissions must be an array");
+  }
+  if (grantablePermissions.length === 0) {
+    throw new Error(
+      "customRoles.grantablePermissions must not be empty when customRoles is enabled",
+    );
+  }
+  for (const p of grantablePermissions) {
+    if (typeof p !== "string" || p.trim().length === 0) {
+      throw new Error(
+        "customRoles.grantablePermissions entries must be non-empty strings",
+      );
+    }
+  }
+}
+
+/**
+ * Validate that a permission set being assigned to (or composed into) a custom
+ * role is a non-empty array of strings, each present in the whitelist. The
+ * server re-validates, but failing fast in the client gives better DX.
+ */
+export function validateCustomRolePermissions(
+  permissions: readonly string[],
+  grantablePermissions: readonly string[],
+): void {
+  if (!Array.isArray(permissions)) {
+    throw new Error("custom role permissions must be an array");
+  }
+  if (permissions.length === 0) {
+    throw new Error("custom role permissions must not be empty");
+  }
+  const allowed = new Set(grantablePermissions);
+  for (const p of permissions) {
+    if (typeof p !== "string" || p.trim().length === 0) {
+      throw new Error("custom role permissions must be non-empty strings");
+    }
+    if (!allowed.has(p)) {
+      throw new Error(
+        `Permission "${p}" is not in customRoles.grantablePermissions`,
+      );
+    }
+  }
+}
+
+/**
  * Validate relation args for hasRelation, addRelation, removeRelation: all non-empty strings.
  */
 export function validateRelationArgs(

--- a/src/component/_generated/api.ts
+++ b/src/component/_generated/api.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as cronSetup from "../cronSetup.js";
+import type * as customRoles from "../customRoles.js";
 import type * as helpers from "../helpers.js";
 import type * as indexed from "../indexed.js";
 import type * as mutations from "../mutations.js";
@@ -26,6 +27,7 @@ import { anyApi, componentsGeneric } from "convex/server";
 
 const fullApi: ApiFromModules<{
   cronSetup: typeof cronSetup;
+  customRoles: typeof customRoles;
   helpers: typeof helpers;
   indexed: typeof indexed;
   mutations: typeof mutations;

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -32,6 +32,137 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         Name
       >;
     };
+    customRoles: {
+      countCustomRoles: FunctionReference<
+        "query",
+        "internal",
+        { tenantId: string },
+        number,
+        Name
+      >;
+      createCustomRole: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          createdBy: string;
+          description?: string;
+          enableAudit?: boolean;
+          grantablePermissions: Array<string>;
+          maxRolesPerTenant?: number;
+          name: string;
+          permissions: Array<string>;
+          tenantId: string;
+        },
+        string,
+        Name
+      >;
+      deleteCustomRole: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          actorId?: string;
+          customRoleId: string;
+          enableAudit?: boolean;
+          force?: boolean;
+          tenantId: string;
+        },
+        {
+          assignmentsRevoked: number;
+          deleted: boolean;
+          effectivePermissionsRemoved: number;
+          effectiveRolesRemoved: number;
+        },
+        Name
+      >;
+      getCustomRole: FunctionReference<
+        "query",
+        "internal",
+        { customRoleId: string; tenantId: string },
+        {
+          _creationTime: number;
+          _id: string;
+          createdAt: number;
+          createdBy: string;
+          description?: string;
+          name: string;
+          permissions: Array<string>;
+          tenantId: string;
+          updatedAt: number;
+        } | null,
+        Name
+      >;
+      getCustomRoleByName: FunctionReference<
+        "query",
+        "internal",
+        { name: string; tenantId: string },
+        {
+          _creationTime: number;
+          _id: string;
+          createdAt: number;
+          createdBy: string;
+          description?: string;
+          name: string;
+          permissions: Array<string>;
+          tenantId: string;
+          updatedAt: number;
+        } | null,
+        Name
+      >;
+      getCustomRolePermissions: FunctionReference<
+        "query",
+        "internal",
+        { customRoleId: string; tenantId: string },
+        { name: string; permissions: Array<string> } | null,
+        Name
+      >;
+      listCustomRoles: FunctionReference<
+        "query",
+        "internal",
+        {
+          paginationOpts: {
+            cursor: string | null;
+            endCursor?: string | null;
+            id?: number;
+            maximumBytesRead?: number;
+            maximumRowsRead?: number;
+            numItems: number;
+          };
+          tenantId: string;
+        },
+        {
+          continueCursor: string;
+          isDone: boolean;
+          page: Array<{
+            _creationTime: number;
+            _id: string;
+            createdAt: number;
+            createdBy: string;
+            description?: string;
+            name: string;
+            permissions: Array<string>;
+            tenantId: string;
+            updatedAt: number;
+          }>;
+        },
+        Name
+      >;
+      updateCustomRoleDefinition: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          actorId?: string;
+          customRoleId: string;
+          description?: string;
+          enableAudit?: boolean;
+          grantablePermissions: Array<string>;
+          name?: string;
+          permissions?: Array<string>;
+          tenantId: string;
+        },
+        { permissions: Array<string>; permissionsChanged: boolean },
+        Name
+      >;
+    };
     indexed: {
       checkPermissionFast: FunctionReference<
         "query",
@@ -217,7 +348,10 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             | "attribute_removed"
             | "relation_added"
             | "relation_removed"
-            | "policy_evaluated";
+            | "policy_evaluated"
+            | "custom_role_created"
+            | "custom_role_updated"
+            | "custom_role_deleted";
           limit?: number;
           paginationOpts?: {
             cursor: string | null;

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -568,6 +568,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         string,
         Name
       >;
+      assignCustomRoleUnified: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          assignedBy?: string;
+          customRoleId: string;
+          enableAudit?: boolean;
+          expiresAt?: number;
+          metadata?: any;
+          policyClassifications?: Record<
+            string,
+            null | "allow" | "deny" | "deferred"
+          >;
+          scope?: { id: string; type: string };
+          tenantId: string;
+          userId: string;
+        },
+        string,
+        Name
+      >;
       assignRolesUnified: FunctionReference<
         "mutation",
         "internal",
@@ -718,6 +738,20 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           userId: string;
         },
         number,
+        Name
+      >;
+      revokeCustomRoleUnified: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          customRoleId: string;
+          enableAudit?: boolean;
+          revokedBy?: string;
+          scope?: { id: string; type: string };
+          tenantId: string;
+          userId: string;
+        },
+        boolean,
         Name
       >;
       revokeRolesUnified: FunctionReference<

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -146,6 +146,27 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         },
         Name
       >;
+      updateCustomRoleAction: FunctionReference<
+        "action",
+        "internal",
+        {
+          actorId?: string;
+          customRoleId: string;
+          description?: string;
+          enableAudit?: boolean;
+          grantablePermissions: Array<string>;
+          name?: string;
+          permissions?: Array<string>;
+          policyClassifications?: Record<
+            string,
+            null | "allow" | "deny" | "deferred"
+          >;
+          rolePermissionsMap: Record<string, Array<string>>;
+          tenantId: string;
+        },
+        { permissionsChanged: boolean; usersRecomputed: number },
+        Name
+      >;
       updateCustomRoleDefinition: FunctionReference<
         "mutation",
         "internal",

--- a/src/component/customRoles.ts
+++ b/src/component/customRoles.ts
@@ -1,0 +1,487 @@
+/**
+ * Custom Roles
+ *
+ * Tenant-admin-defined role bundles, composed at runtime from a SaaS-provider-
+ * supplied permission whitelist. Identified by `Id<"customRoles">`; stored in
+ * `roleAssignments.role` as the namespaced string `"custom:<id>"` so the
+ * existing read path (`hasRoleFast`, `checkPermissionFast`) treats them
+ * uniformly with system roles. The whitelist (`grantablePermissions`) is
+ * passed as a mutation arg by the developer's app — the SaaS provider owns
+ * the whitelist; tenant admins compose, never invent.
+ *
+ * See plan: /Users/dj/.claude/plans/create-a-plan-to-gleaming-fountain.md
+ */
+
+import { v } from "convex/values";
+import { ConvexError } from "convex/values";
+import { paginationOptsValidator } from "convex/server";
+import { mutation, query } from "./_generated/server.js";
+import type { Id } from "./_generated/dataModel.js";
+
+const DEFAULT_MAX_ROLES_PER_TENANT = 100;
+const CUSTOM_ROLE_PREFIX = "custom:";
+
+/** Build the namespaced role string stored in `roleAssignments.role`. */
+export function customRoleStringFromId(id: Id<"customRoles">): string {
+  return `${CUSTOM_ROLE_PREFIX}${id}`;
+}
+
+const customRoleDocValidator = v.object({
+  _id: v.id("customRoles"),
+  _creationTime: v.number(),
+  tenantId: v.string(),
+  name: v.string(),
+  permissions: v.array(v.string()),
+  description: v.optional(v.string()),
+  createdBy: v.string(),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+});
+
+/**
+ * Validate that every requested permission appears in the SaaS-provider
+ * whitelist. Empty whitelist is a configuration error caught at SDK init,
+ * so we treat it here as zero grantable permissions.
+ */
+function assertPermissionsGrantable(
+  permissions: readonly string[],
+  grantablePermissions: readonly string[],
+): void {
+  const allowed = new Set(grantablePermissions);
+  for (const perm of permissions) {
+    if (!allowed.has(perm)) {
+      throw new ConvexError({
+        code: "PERMISSION_NOT_GRANTABLE",
+        message: `Permission "${perm}" is not in grantablePermissions whitelist`,
+        permission: perm,
+      });
+    }
+  }
+}
+
+/**
+ * Create a tenant-scoped custom role.
+ *
+ * Throws ConvexError on:
+ *   - PERMISSION_NOT_GRANTABLE — a permission isn't in the whitelist
+ *   - CUSTOM_ROLE_LIMIT_EXCEEDED — tenant already at the cap
+ *   - CUSTOM_ROLE_NAME_TAKEN — a role with this name already exists in the tenant
+ */
+export const createCustomRole = mutation({
+  args: {
+    tenantId: v.string(),
+    name: v.string(),
+    permissions: v.array(v.string()),
+    description: v.optional(v.string()),
+    createdBy: v.string(),
+    grantablePermissions: v.array(v.string()),
+    maxRolesPerTenant: v.optional(v.number()),
+    enableAudit: v.optional(v.boolean()),
+  },
+  returns: v.id("customRoles"),
+  handler: async (ctx, args) => {
+    if (args.name.trim().length === 0) {
+      throw new ConvexError({
+        code: "INVALID_CUSTOM_ROLE_NAME",
+        message: "Custom role name must be a non-empty string",
+      });
+    }
+
+    assertPermissionsGrantable(args.permissions, args.grantablePermissions);
+
+    const cap = args.maxRolesPerTenant ?? DEFAULT_MAX_ROLES_PER_TENANT;
+    const existingForTenant = await ctx.db
+      .query("customRoles")
+      .withIndex("by_tenant", (q) => q.eq("tenantId", args.tenantId))
+      .take(cap + 1);
+
+    if (existingForTenant.length >= cap) {
+      throw new ConvexError({
+        code: "CUSTOM_ROLE_LIMIT_EXCEEDED",
+        message: `Tenant has reached the custom role limit (${cap})`,
+        limit: cap,
+      });
+    }
+
+    const nameClash = await ctx.db
+      .query("customRoles")
+      .withIndex("by_tenant_name", (q) =>
+        q.eq("tenantId", args.tenantId).eq("name", args.name),
+      )
+      .first();
+
+    if (nameClash !== null) {
+      throw new ConvexError({
+        code: "CUSTOM_ROLE_NAME_TAKEN",
+        message: `A custom role named "${args.name}" already exists in this tenant`,
+        name: args.name,
+      });
+    }
+
+    const now = Date.now();
+    const id = await ctx.db.insert("customRoles", {
+      tenantId: args.tenantId,
+      name: args.name,
+      permissions: args.permissions,
+      description: args.description,
+      createdBy: args.createdBy,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    if (args.enableAudit) {
+      await ctx.db.insert("auditLog", {
+        tenantId: args.tenantId,
+        timestamp: now,
+        action: "custom_role_created",
+        userId: args.createdBy,
+        actorId: args.createdBy,
+        details: {
+          scope: undefined,
+          customRoleId: id,
+          customRoleName: args.name,
+        },
+      });
+    }
+
+    return id;
+  },
+});
+
+/**
+ * Update a custom role definition. Returns the new permission list so the
+ * caller (action layer) can fan out `recomputeUser` over all users holding
+ * this role.
+ *
+ * If neither `name`, `permissions`, nor `description` is provided, this is a
+ * no-op (returns the current row).
+ */
+export const updateCustomRoleDefinition = mutation({
+  args: {
+    customRoleId: v.id("customRoles"),
+    tenantId: v.string(),
+    name: v.optional(v.string()),
+    permissions: v.optional(v.array(v.string())),
+    description: v.optional(v.string()),
+    grantablePermissions: v.array(v.string()),
+    actorId: v.optional(v.string()),
+    enableAudit: v.optional(v.boolean()),
+  },
+  returns: v.object({
+    permissions: v.array(v.string()),
+    permissionsChanged: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.customRoleId);
+    if (existing === null) {
+      throw new ConvexError({
+        code: "CUSTOM_ROLE_NOT_FOUND",
+        message: "Custom role does not exist",
+        customRoleId: args.customRoleId,
+      });
+    }
+    if (existing.tenantId !== args.tenantId) {
+      // Cross-tenant access attempt — treat as not-found to avoid leaking
+      // the existence of roles from another tenant.
+      throw new ConvexError({
+        code: "CUSTOM_ROLE_NOT_FOUND",
+        message: "Custom role does not exist",
+        customRoleId: args.customRoleId,
+      });
+    }
+
+    if (args.permissions !== undefined) {
+      assertPermissionsGrantable(args.permissions, args.grantablePermissions);
+    }
+
+    if (args.name !== undefined && args.name !== existing.name) {
+      if (args.name.trim().length === 0) {
+        throw new ConvexError({
+          code: "INVALID_CUSTOM_ROLE_NAME",
+          message: "Custom role name must be a non-empty string",
+        });
+      }
+      const clash = await ctx.db
+        .query("customRoles")
+        .withIndex("by_tenant_name", (q) =>
+          q.eq("tenantId", args.tenantId).eq("name", args.name as string),
+        )
+        .first();
+      if (clash !== null && clash._id !== existing._id) {
+        throw new ConvexError({
+          code: "CUSTOM_ROLE_NAME_TAKEN",
+          message: `A custom role named "${args.name}" already exists in this tenant`,
+          name: args.name,
+        });
+      }
+    }
+
+    const now = Date.now();
+    const patch: Partial<{
+      name: string;
+      permissions: string[];
+      description: string | undefined;
+      updatedAt: number;
+    }> = { updatedAt: now };
+    if (args.name !== undefined) patch.name = args.name;
+    if (args.permissions !== undefined) patch.permissions = args.permissions;
+    if (args.description !== undefined) patch.description = args.description;
+
+    await ctx.db.patch(args.customRoleId, patch);
+
+    const newPermissions = args.permissions ?? existing.permissions;
+    const permissionsChanged =
+      args.permissions !== undefined &&
+      !arraysEqualAsSets(existing.permissions, args.permissions);
+
+    if (args.enableAudit) {
+      await ctx.db.insert("auditLog", {
+        tenantId: args.tenantId,
+        timestamp: now,
+        action: "custom_role_updated",
+        userId: args.actorId ?? existing.createdBy,
+        actorId: args.actorId,
+        details: {
+          scope: undefined,
+          customRoleId: args.customRoleId,
+          customRoleName: args.name ?? existing.name,
+        },
+      });
+    }
+
+    return {
+      permissions: newPermissions,
+      permissionsChanged,
+    };
+  },
+});
+
+function arraysEqualAsSets(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const setA = new Set(a);
+  for (const x of b) if (!setA.has(x)) return false;
+  return true;
+}
+
+/**
+ * Delete a custom role definition. Refuses if any user currently holds it
+ * unless `force: true`, in which case all assignments and their materialized
+ * rows in `effectiveRoles` / `effectivePermissions` are removed first.
+ */
+export const deleteCustomRole = mutation({
+  args: {
+    customRoleId: v.id("customRoles"),
+    tenantId: v.string(),
+    force: v.optional(v.boolean()),
+    actorId: v.optional(v.string()),
+    enableAudit: v.optional(v.boolean()),
+  },
+  returns: v.object({
+    deleted: v.boolean(),
+    assignmentsRevoked: v.number(),
+    effectiveRolesRemoved: v.number(),
+    effectivePermissionsRemoved: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.customRoleId);
+    if (existing === null || existing.tenantId !== args.tenantId) {
+      throw new ConvexError({
+        code: "CUSTOM_ROLE_NOT_FOUND",
+        message: "Custom role does not exist",
+        customRoleId: args.customRoleId,
+      });
+    }
+
+    const roleString = customRoleStringFromId(args.customRoleId);
+
+    const assignments = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_tenant_role", (q) =>
+        q.eq("tenantId", args.tenantId).eq("role", roleString),
+      )
+      .take(4000);
+
+    if (assignments.length > 0 && args.force !== true) {
+      throw new ConvexError({
+        code: "CUSTOM_ROLE_IN_USE",
+        message: `Custom role "${existing.name}" is assigned to ${assignments.length} user(s). Pass force: true to revoke and delete.`,
+        assignmentCount: assignments.length,
+      });
+    }
+
+    let effectiveRolesRemoved = 0;
+    let effectivePermissionsRemoved = 0;
+
+    for (const assignment of assignments) {
+      // Source row
+      await ctx.db.delete(assignment._id);
+
+      // effectiveRoles rows for this user × this role
+      const effRoles = await ctx.db
+        .query("effectiveRoles")
+        .withIndex("by_tenant_user", (q) =>
+          q.eq("tenantId", args.tenantId).eq("userId", assignment.userId),
+        )
+        .take(4000);
+      for (const er of effRoles) {
+        if (er.role === roleString) {
+          await ctx.db.delete(er._id);
+          effectiveRolesRemoved++;
+        }
+      }
+
+      // effectivePermissions rows that listed this role as a source
+      const effPerms = await ctx.db
+        .query("effectivePermissions")
+        .withIndex("by_tenant_user", (q) =>
+          q.eq("tenantId", args.tenantId).eq("userId", assignment.userId),
+        )
+        .take(4000);
+      for (const ep of effPerms) {
+        if (!ep.sources.includes(roleString)) continue;
+        const remainingSources = ep.sources.filter((s) => s !== roleString);
+        if (
+          remainingSources.length === 0 &&
+          ep.directGrant !== true &&
+          ep.directDeny !== true
+        ) {
+          await ctx.db.delete(ep._id);
+          effectivePermissionsRemoved++;
+        } else if (remainingSources.length !== ep.sources.length) {
+          await ctx.db.patch(ep._id, { sources: remainingSources });
+        }
+      }
+    }
+
+    await ctx.db.delete(args.customRoleId);
+
+    if (args.enableAudit) {
+      await ctx.db.insert("auditLog", {
+        tenantId: args.tenantId,
+        timestamp: Date.now(),
+        action: "custom_role_deleted",
+        userId: args.actorId ?? existing.createdBy,
+        actorId: args.actorId,
+        details: {
+          scope: undefined,
+          customRoleId: args.customRoleId,
+          customRoleName: existing.name,
+        },
+      });
+    }
+
+    return {
+      deleted: true,
+      assignmentsRevoked: assignments.length,
+      effectiveRolesRemoved,
+      effectivePermissionsRemoved,
+    };
+  },
+});
+
+/**
+ * List custom roles for a tenant (paginated).
+ */
+export const listCustomRoles = query({
+  args: {
+    tenantId: v.string(),
+    paginationOpts: paginationOptsValidator,
+  },
+  returns: v.object({
+    page: v.array(customRoleDocValidator),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query("customRoles")
+      .withIndex("by_tenant", (q) => q.eq("tenantId", args.tenantId))
+      .paginate(args.paginationOpts);
+    return {
+      page: result.page,
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
+
+/**
+ * Fetch a single custom role by id, verifying tenant ownership.
+ * Returns null if the role does not exist or belongs to a different tenant.
+ */
+export const getCustomRole = query({
+  args: {
+    customRoleId: v.id("customRoles"),
+    tenantId: v.string(),
+  },
+  returns: v.union(customRoleDocValidator, v.null()),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.customRoleId);
+    if (row === null || row.tenantId !== args.tenantId) {
+      return null;
+    }
+    return row;
+  },
+});
+
+/**
+ * Fetch a single custom role by tenant + name (the human-readable lookup).
+ */
+export const getCustomRoleByName = query({
+  args: {
+    tenantId: v.string(),
+    name: v.string(),
+  },
+  returns: v.union(customRoleDocValidator, v.null()),
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("customRoles")
+      .withIndex("by_tenant_name", (q) =>
+        q.eq("tenantId", args.tenantId).eq("name", args.name),
+      )
+      .first();
+  },
+});
+
+/**
+ * Internal helper used by `assignCustomRoleUnified` to fetch the snapshot
+ * permission list. Returns null if the role does not exist in the given tenant.
+ */
+export const getCustomRolePermissions = query({
+  args: {
+    customRoleId: v.id("customRoles"),
+    tenantId: v.string(),
+  },
+  returns: v.union(
+    v.object({
+      permissions: v.array(v.string()),
+      name: v.string(),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.customRoleId);
+    if (row === null || row.tenantId !== args.tenantId) {
+      return null;
+    }
+    return { permissions: row.permissions, name: row.name };
+  },
+});
+
+/**
+ * Count custom roles in a tenant — useful for admin UIs and the
+ * `maxRolesPerTenant` cap check (already enforced inside `createCustomRole`).
+ */
+export const countCustomRoles = query({
+  args: {
+    tenantId: v.string(),
+  },
+  returns: v.number(),
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("customRoles")
+      .withIndex("by_tenant", (q) => q.eq("tenantId", args.tenantId))
+      .take(DEFAULT_MAX_ROLES_PER_TENANT * 2);
+    return rows.length;
+  },
+});

--- a/src/component/customRoles.ts
+++ b/src/component/customRoles.ts
@@ -15,7 +15,8 @@
 import { v } from "convex/values";
 import { ConvexError } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
-import { mutation, query } from "./_generated/server.js";
+import { action, mutation, query } from "./_generated/server.js";
+import { api } from "./_generated/api.js";
 import type { Id } from "./_generated/dataModel.js";
 
 const DEFAULT_MAX_ROLES_PER_TENANT = 100;
@@ -483,5 +484,100 @@ export const countCustomRoles = query({
       .withIndex("by_tenant", (q) => q.eq("tenantId", args.tenantId))
       .take(DEFAULT_MAX_ROLES_PER_TENANT * 2);
     return rows.length;
+  },
+});
+
+/**
+ * Update a custom role and cascade the change to every user holding it.
+ *
+ * Phase 1 (mutation): patches the customRoles row, validates the new
+ * permissions against `grantablePermissions`, and reports whether the
+ * permission set actually changed (set-equality, not array-equality).
+ *
+ * Phase 2 (cascade): if the permission set changed, walks every user with
+ * this role assigned and calls `recomputeUser` to re-materialize their
+ * `effectivePermissions`. Each user is one mutation transaction; the action
+ * iterates pages of 50 users at a time. If only the name/description changed,
+ * the cascade is skipped (no effective rows reference role names beyond the
+ * namespaced id, which is stable).
+ *
+ * Direct grants and direct denies on each user are preserved (recomputeUser
+ * keeps `directGrant === true` / `directDeny === true` rows).
+ */
+export const updateCustomRoleAction = action({
+  args: {
+    tenantId: v.string(),
+    customRoleId: v.id("customRoles"),
+    name: v.optional(v.string()),
+    permissions: v.optional(v.array(v.string())),
+    description: v.optional(v.string()),
+    grantablePermissions: v.array(v.string()),
+    rolePermissionsMap: v.record(v.string(), v.array(v.string())),
+    actorId: v.optional(v.string()),
+    enableAudit: v.optional(v.boolean()),
+    policyClassifications: v.optional(
+      v.record(
+        v.string(),
+        v.union(
+          v.null(),
+          v.literal("allow"),
+          v.literal("deny"),
+          v.literal("deferred"),
+        ),
+      ),
+    ),
+  },
+  returns: v.object({
+    permissionsChanged: v.boolean(),
+    usersRecomputed: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const updateResult: { permissions: string[]; permissionsChanged: boolean } =
+      await ctx.runMutation(api.customRoles.updateCustomRoleDefinition, {
+        customRoleId: args.customRoleId,
+        tenantId: args.tenantId,
+        name: args.name,
+        permissions: args.permissions,
+        description: args.description,
+        grantablePermissions: args.grantablePermissions,
+        actorId: args.actorId,
+        enableAudit: args.enableAudit,
+      });
+
+    if (!updateResult.permissionsChanged) {
+      return { permissionsChanged: false, usersRecomputed: 0 };
+    }
+
+    const role = customRoleStringFromId(args.customRoleId);
+    let cursor: string | null = null;
+    const seen = new Set<string>();
+
+    while (true) {
+      const batch: {
+        userIds: string[];
+        isDone: boolean;
+        continueCursor: string;
+      } = await ctx.runQuery(api.unified.listUserIdsWithRole, {
+        tenantId: args.tenantId,
+        role,
+        paginationOpts: { numItems: 50, cursor },
+      });
+
+      for (const userId of batch.userIds) {
+        if (seen.has(userId)) continue;
+        seen.add(userId);
+        await ctx.runMutation(api.unified.recomputeUser, {
+          tenantId: args.tenantId,
+          userId,
+          rolePermissionsMap: args.rolePermissionsMap,
+          policyClassifications: args.policyClassifications,
+        });
+      }
+
+      if (batch.isDone) break;
+      cursor = batch.continueCursor;
+    }
+
+    return { permissionsChanged: true, usersRecomputed: seen.size };
   },
 });

--- a/src/component/customRoles.ts
+++ b/src/component/customRoles.ts
@@ -15,9 +15,11 @@
 import { v } from "convex/values";
 import { ConvexError } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
+import { paginator } from "convex-helpers/server/pagination";
 import { action, mutation, query } from "./_generated/server.js";
 import { api } from "./_generated/api.js";
 import type { Id } from "./_generated/dataModel.js";
+import schema from "./schema.js";
 
 const DEFAULT_MAX_ROLES_PER_TENANT = 100;
 const CUSTOM_ROLE_PREFIX = "custom:";
@@ -394,7 +396,9 @@ export const listCustomRoles = query({
     continueCursor: v.string(),
   }),
   handler: async (ctx, args) => {
-    const result = await ctx.db
+    // Use convex-helpers' paginator: native ctx.db.paginate() is not supported
+    // inside Convex components (see resolved issue #41 — same root cause).
+    const result = await paginator(ctx.db, schema)
       .query("customRoles")
       .withIndex("by_tenant", (q) => q.eq("tenantId", args.tenantId))
       .paginate(args.paginationOpts);

--- a/src/component/queries.ts
+++ b/src/component/queries.ts
@@ -250,7 +250,10 @@ const auditLogActionValidator = v.union(
   v.literal("attribute_removed"),
   v.literal("relation_added"),
   v.literal("relation_removed"),
-  v.literal("policy_evaluated")
+  v.literal("policy_evaluated"),
+  v.literal("custom_role_created"),
+  v.literal("custom_role_updated"),
+  v.literal("custom_role_deleted")
 );
 
 const auditEntryShape = v.object({

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -155,6 +155,18 @@ export default defineSchema({
     ])
     .index("by_tenant_inherited_from", ["tenantId", "inheritedFrom"]),
 
+  customRoles: defineTable({
+    tenantId: v.string(),
+    name: v.string(),
+    permissions: v.array(v.string()),
+    description: v.optional(v.string()),
+    createdBy: v.string(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_tenant", ["tenantId"])
+    .index("by_tenant_name", ["tenantId", "name"]),
+
   auditLog: defineTable({
     tenantId: v.optional(v.string()),
     timestamp: v.number(),
@@ -168,7 +180,10 @@ export default defineSchema({
       v.literal("attribute_removed"),
       v.literal("relation_added"),
       v.literal("relation_removed"),
-      v.literal("policy_evaluated")
+      v.literal("policy_evaluated"),
+      v.literal("custom_role_created"),
+      v.literal("custom_role_updated"),
+      v.literal("custom_role_deleted")
     ),
     userId: v.string(),
     actorId: v.optional(v.string()),
@@ -188,6 +203,9 @@ export default defineSchema({
       relation: v.optional(v.string()),
       subject: v.optional(v.string()),
       object: v.optional(v.string()),
+      // v2.4: custom role lifecycle details
+      customRoleId: v.optional(v.string()),
+      customRoleName: v.optional(v.string()),
     }),
   })
     .index("by_tenant_user", ["tenantId", "userId"])

--- a/src/component/tests/customRoleAssignment.test.ts
+++ b/src/component/tests/customRoleAssignment.test.ts
@@ -1,0 +1,313 @@
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { ConvexError } from "convex/values";
+import schema from "../schema.js";
+import { api } from "../_generated/api.js";
+import { customRoleStringFromId } from "../customRoles.js";
+
+const modules = import.meta.glob("../**/*.ts");
+
+const TENANT_A = "tenant-acme";
+const TENANT_B = "tenant-globex";
+const ADMIN = "admin-1";
+const USER = "user-1";
+const GRANTABLE = ["docs:read", "docs:write", "docs:delete", "billing:read"];
+
+async function createRole(
+  t: ReturnType<typeof convexTest>,
+  opts?: { tenantId?: string; name?: string; permissions?: string[] },
+) {
+  return await t.mutation(api.customRoles.createCustomRole, {
+    tenantId: opts?.tenantId ?? TENANT_A,
+    name: opts?.name ?? "Editor",
+    permissions: opts?.permissions ?? ["docs:read", "docs:write"],
+    createdBy: ADMIN,
+    grantablePermissions: GRANTABLE,
+  });
+}
+
+describe("assignCustomRoleUnified", () => {
+  it("assigns a custom role and writes to all three tables", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await createRole(t);
+
+    const assignmentId = await t.mutation(
+      api.unified.assignCustomRoleUnified,
+      {
+        tenantId: TENANT_A,
+        userId: USER,
+        customRoleId: roleId,
+        assignedBy: ADMIN,
+      },
+    );
+    expect(typeof assignmentId).toBe("string");
+
+    // hasRole should report true under the namespaced role string
+    const has = await t.query(api.indexed.hasRoleFast, {
+      tenantId: TENANT_A,
+      userId: USER,
+      role: customRoleStringFromId(roleId),
+    });
+    expect(has).toBe(true);
+
+    // can() should permit each granted permission
+    const canRead = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+    });
+    expect(canRead.allowed).toBe(true);
+
+    const canWrite = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:write",
+    });
+    expect(canWrite.allowed).toBe(true);
+
+    // and deny what wasn't granted
+    const canDelete = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:delete",
+    });
+    expect(canDelete.allowed).toBe(false);
+  });
+
+  it("is idempotent — second assign extends expiry instead of duplicating", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await createRole(t);
+
+    const id1 = await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      customRoleId: roleId,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const id2 = await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      customRoleId: roleId,
+      expiresAt: Date.now() + 120_000, // longer
+    });
+
+    expect(id1).toBe(id2);
+
+    // Only one assignment row should exist
+    const roles = await t.query(api.queries.getUserRoles, {
+      tenantId: TENANT_A,
+      userId: USER,
+    });
+    expect(roles).toHaveLength(1);
+  });
+
+  it("rejects assignment when the customRoleId belongs to a different tenant", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await createRole(t, { tenantId: TENANT_A });
+
+    await expect(
+      t.mutation(api.unified.assignCustomRoleUnified, {
+        tenantId: TENANT_B, // wrong tenant
+        userId: USER,
+        customRoleId: roleId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("supports scoped assignment", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await createRole(t);
+
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      customRoleId: roleId,
+      scope: { type: "team", id: "team-7" },
+    });
+
+    // Permission check inside the scope: allowed
+    const inScope = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+      scope: { type: "team", id: "team-7" },
+    });
+    expect(inScope.allowed).toBe(true);
+
+    // Permission check outside the scope: denied
+    const outOfScope = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+      scope: { type: "team", id: "team-other" },
+    });
+    expect(outOfScope.allowed).toBe(false);
+
+    // Global permission check: denied (no global grant)
+    const global = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+    });
+    expect(global.allowed).toBe(false);
+  });
+
+  it("writes audit log with customRoleId/customRoleName when enabled", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await createRole(t, { name: "Reviewer" });
+
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      customRoleId: roleId,
+      assignedBy: ADMIN,
+      enableAudit: true,
+    });
+
+    const logsResult = await t.query(api.queries.getAuditLog, {
+      tenantId: TENANT_A,
+    });
+    const logs = Array.isArray(logsResult) ? logsResult : logsResult.page;
+    const assigned = logs.find((l) => l.action === "role_assigned");
+    expect(assigned).toBeDefined();
+    const details = assigned?.details as {
+      customRoleId?: string;
+      customRoleName?: string;
+    };
+    expect(details.customRoleId).toBe(roleId);
+    expect(details.customRoleName).toBe("Reviewer");
+  });
+
+  it("custom + system roles compose: union of permissions", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await createRole(t, { permissions: ["docs:read"] });
+
+    // System role assignment grants docs:write
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      role: "writer",
+      rolePermissions: ["docs:write"],
+    });
+    // Custom role assignment grants docs:read
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      customRoleId: roleId,
+    });
+
+    const r = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+    });
+    expect(r.allowed).toBe(true);
+
+    const w = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:write",
+    });
+    expect(w.allowed).toBe(true);
+  });
+});
+
+describe("revokeCustomRoleUnified", () => {
+  it("revokes a custom role and removes effective rows", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await createRole(t);
+
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      customRoleId: roleId,
+    });
+
+    const revoked = await t.mutation(api.unified.revokeCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      customRoleId: roleId,
+    });
+    expect(revoked).toBe(true);
+
+    const has = await t.query(api.indexed.hasRoleFast, {
+      tenantId: TENANT_A,
+      userId: USER,
+      role: customRoleStringFromId(roleId),
+    });
+    expect(has).toBe(false);
+
+    const canRead = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+    });
+    expect(canRead.allowed).toBe(false);
+  });
+
+  it("is idempotent — revoking when no assignment exists returns false", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await createRole(t);
+
+    const result = await t.mutation(api.unified.revokeCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      customRoleId: roleId,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("rejects cross-tenant revoke as not-found", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await createRole(t, { tenantId: TENANT_A });
+
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      customRoleId: roleId,
+    });
+
+    await expect(
+      t.mutation(api.unified.revokeCustomRoleUnified, {
+        tenantId: TENANT_B,
+        userId: USER,
+        customRoleId: roleId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("revoking custom role does not strip permissions held via another source", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await createRole(t, { permissions: ["docs:read"] });
+
+    // Direct grant of docs:read
+    await t.mutation(api.unified.grantPermissionUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+      createdBy: ADMIN,
+    });
+    // Custom role also grants docs:read
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      customRoleId: roleId,
+    });
+
+    // Revoke the custom role
+    await t.mutation(api.unified.revokeCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      customRoleId: roleId,
+    });
+
+    // docs:read still allowed because of the direct grant
+    const canRead = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+    });
+    expect(canRead.allowed).toBe(true);
+  });
+});

--- a/src/component/tests/customRoleCascade.test.ts
+++ b/src/component/tests/customRoleCascade.test.ts
@@ -1,0 +1,241 @@
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import schema from "../schema.js";
+import { api } from "../_generated/api.js";
+
+const modules = import.meta.glob("../**/*.ts");
+
+const TENANT_A = "tenant-acme";
+const ADMIN = "admin-1";
+const GRANTABLE = ["docs:read", "docs:write", "docs:archive", "docs:delete"];
+
+async function setupRoleAndUsers(
+  t: ReturnType<typeof convexTest>,
+  initialPerms: string[],
+  userIds: string[],
+) {
+  const roleId = await t.mutation(api.customRoles.createCustomRole, {
+    tenantId: TENANT_A,
+    name: "Editor",
+    permissions: initialPerms,
+    createdBy: ADMIN,
+    grantablePermissions: GRANTABLE,
+  });
+  for (const userId of userIds) {
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId,
+      customRoleId: roleId,
+    });
+  }
+  return roleId;
+}
+
+describe("updateCustomRoleAction: cascade-on-update fan-out", () => {
+  it("propagates added permissions to all assigned users", async () => {
+    const t = convexTest(schema, modules);
+    const users = ["user-1", "user-2", "user-3"];
+    const roleId = await setupRoleAndUsers(t, ["docs:read"], users);
+
+    // Sanity: nobody can write yet
+    for (const u of users) {
+      const r = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT_A,
+        userId: u,
+        permission: "docs:write",
+      });
+      expect(r.allowed).toBe(false);
+    }
+
+    const result = await t.action(api.customRoles.updateCustomRoleAction, {
+      tenantId: TENANT_A,
+      customRoleId: roleId,
+      permissions: ["docs:read", "docs:write"],
+      grantablePermissions: GRANTABLE,
+      rolePermissionsMap: {},
+    });
+
+    expect(result.permissionsChanged).toBe(true);
+    expect(result.usersRecomputed).toBe(3);
+
+    // All three users now can write
+    for (const u of users) {
+      const r = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT_A,
+        userId: u,
+        permission: "docs:write",
+      });
+      expect(r.allowed).toBe(true);
+    }
+  });
+
+  it("propagates removed permissions to all assigned users", async () => {
+    const t = convexTest(schema, modules);
+    const users = ["user-1", "user-2"];
+    const roleId = await setupRoleAndUsers(
+      t,
+      ["docs:read", "docs:write"],
+      users,
+    );
+
+    // Sanity: both can write
+    for (const u of users) {
+      const r = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT_A,
+        userId: u,
+        permission: "docs:write",
+      });
+      expect(r.allowed).toBe(true);
+    }
+
+    await t.action(api.customRoles.updateCustomRoleAction, {
+      tenantId: TENANT_A,
+      customRoleId: roleId,
+      permissions: ["docs:read"],
+      grantablePermissions: GRANTABLE,
+      rolePermissionsMap: {},
+    });
+
+    // Nobody can write anymore; everyone still reads
+    for (const u of users) {
+      const w = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT_A,
+        userId: u,
+        permission: "docs:write",
+      });
+      expect(w.allowed).toBe(false);
+
+      const r = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT_A,
+        userId: u,
+        permission: "docs:read",
+      });
+      expect(r.allowed).toBe(true);
+    }
+  });
+
+  it("skips fan-out (usersRecomputed=0) when permissions are unchanged", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await setupRoleAndUsers(t, ["docs:read", "docs:write"], [
+      "user-1",
+    ]);
+
+    const result = await t.action(api.customRoles.updateCustomRoleAction, {
+      tenantId: TENANT_A,
+      customRoleId: roleId,
+      permissions: ["docs:write", "docs:read"], // reordered = same set
+      grantablePermissions: GRANTABLE,
+      rolePermissionsMap: {},
+    });
+
+    expect(result.permissionsChanged).toBe(false);
+    expect(result.usersRecomputed).toBe(0);
+  });
+
+  it("preserves direct permission grants across cascade", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await setupRoleAndUsers(t, ["docs:read"], ["user-1"]);
+
+    // Direct grant unrelated to the custom role
+    await t.mutation(api.unified.grantPermissionUnified, {
+      tenantId: TENANT_A,
+      userId: "user-1",
+      permission: "docs:archive",
+      createdBy: ADMIN,
+    });
+
+    // Update custom role permissions
+    await t.action(api.customRoles.updateCustomRoleAction, {
+      tenantId: TENANT_A,
+      customRoleId: roleId,
+      permissions: ["docs:read", "docs:write"],
+      grantablePermissions: GRANTABLE,
+      rolePermissionsMap: {},
+    });
+
+    // Direct grant survives the recompute
+    const archive = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: "user-1",
+      permission: "docs:archive",
+    });
+    expect(archive.allowed).toBe(true);
+
+    // Old role permission still there
+    const read = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: "user-1",
+      permission: "docs:read",
+    });
+    expect(read.allowed).toBe(true);
+
+    // New permission applied
+    const write = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: "user-1",
+      permission: "docs:write",
+    });
+    expect(write.allowed).toBe(true);
+  });
+
+  it("preserves system role permissions when cascading a custom role update", async () => {
+    const t = convexTest(schema, modules);
+    const roleId = await setupRoleAndUsers(t, ["docs:read"], ["user-1"]);
+
+    // Add a system role too
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: TENANT_A,
+      userId: "user-1",
+      role: "billing_admin",
+      rolePermissions: ["billing:read"],
+    });
+
+    // Cascade an update to the custom role — system roles need to survive
+    await t.action(api.customRoles.updateCustomRoleAction, {
+      tenantId: TENANT_A,
+      customRoleId: roleId,
+      permissions: ["docs:read", "docs:write"],
+      grantablePermissions: GRANTABLE,
+      // Pass the system role permissions map so recomputeUser preserves them
+      rolePermissionsMap: { billing_admin: ["billing:read"] },
+    });
+
+    // System role permission preserved
+    const billing = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: "user-1",
+      permission: "billing:read",
+    });
+    expect(billing.allowed).toBe(true);
+
+    // New custom role permission applied
+    const write = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: "user-1",
+      permission: "docs:write",
+    });
+    expect(write.allowed).toBe(true);
+  });
+
+  it("recomputeUser internally resolves custom roles when not in the map", async () => {
+    const t = convexTest(schema, modules);
+    // User has only a custom role
+    await setupRoleAndUsers(t, ["docs:read"], ["user-1"]);
+
+    // Call recomputeUser directly with an empty map (as syncRoleAction would
+    // when the user only holds custom roles). The custom role's permissions
+    // must be re-materialized from the customRoles table, not zeroed out.
+    await t.mutation(api.unified.recomputeUser, {
+      tenantId: TENANT_A,
+      userId: "user-1",
+      rolePermissionsMap: {}, // no system roles to inject
+    });
+
+    const read = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: "user-1",
+      permission: "docs:read",
+    });
+    expect(read.allowed).toBe(true);
+  });
+});

--- a/src/component/tests/customRoles.test.ts
+++ b/src/component/tests/customRoles.test.ts
@@ -1,0 +1,529 @@
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { ConvexError } from "convex/values";
+import schema from "../schema.js";
+import { api } from "../_generated/api.js";
+import { customRoleStringFromId } from "../customRoles.js";
+
+const modules = import.meta.glob("../**/*.ts");
+
+const TENANT_A = "tenant-acme";
+const TENANT_B = "tenant-globex";
+const ADMIN_USER = "admin-1";
+const GRANTABLE = ["docs:read", "docs:write", "docs:delete", "billing:read"];
+
+describe("customRoles: createCustomRole", () => {
+  it("creates a custom role and returns its id", async () => {
+    const t = convexTest(schema, modules);
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Senior Editor",
+      permissions: ["docs:read", "docs:write"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    expect(typeof id).toBe("string");
+
+    const fetched = await t.query(api.customRoles.getCustomRole, {
+      customRoleId: id,
+      tenantId: TENANT_A,
+    });
+    expect(fetched).not.toBeNull();
+    expect(fetched?.name).toBe("Senior Editor");
+    expect(fetched?.permissions).toEqual(["docs:read", "docs:write"]);
+    expect(fetched?.createdBy).toBe(ADMIN_USER);
+  });
+
+  it("rejects permissions not in grantablePermissions whitelist", async () => {
+    const t = convexTest(schema, modules);
+
+    await expect(
+      t.mutation(api.customRoles.createCustomRole, {
+        tenantId: TENANT_A,
+        name: "Sneaky",
+        permissions: ["docs:read", "system:*"], // system:* not in whitelist
+        createdBy: ADMIN_USER,
+        grantablePermissions: GRANTABLE,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("rejects empty role names", async () => {
+    const t = convexTest(schema, modules);
+
+    await expect(
+      t.mutation(api.customRoles.createCustomRole, {
+        tenantId: TENANT_A,
+        name: "   ",
+        permissions: ["docs:read"],
+        createdBy: ADMIN_USER,
+        grantablePermissions: GRANTABLE,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("rejects duplicate names within the same tenant", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    await expect(
+      t.mutation(api.customRoles.createCustomRole, {
+        tenantId: TENANT_A,
+        name: "Editor",
+        permissions: ["docs:write"],
+        createdBy: ADMIN_USER,
+        grantablePermissions: GRANTABLE,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("allows the same name in a different tenant", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_B,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    expect(typeof id).toBe("string");
+  });
+
+  it("enforces maxRolesPerTenant cap", async () => {
+    const t = convexTest(schema, modules);
+
+    // Create 3 roles with cap of 3
+    for (let i = 0; i < 3; i++) {
+      await t.mutation(api.customRoles.createCustomRole, {
+        tenantId: TENANT_A,
+        name: `Role ${i}`,
+        permissions: ["docs:read"],
+        createdBy: ADMIN_USER,
+        grantablePermissions: GRANTABLE,
+        maxRolesPerTenant: 3,
+      });
+    }
+
+    // 4th should fail
+    await expect(
+      t.mutation(api.customRoles.createCustomRole, {
+        tenantId: TENANT_A,
+        name: "Role 3",
+        permissions: ["docs:read"],
+        createdBy: ADMIN_USER,
+        grantablePermissions: GRANTABLE,
+        maxRolesPerTenant: 3,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("writes an audit log entry when enableAudit is true", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Audited Role",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+      enableAudit: true,
+    });
+
+    const logsResult = await t.query(api.queries.getAuditLog, {
+      tenantId: TENANT_A,
+      limit: 10,
+    });
+    const logs = Array.isArray(logsResult) ? logsResult : logsResult.page;
+    const created = logs.find((l) => l.action === "custom_role_created");
+    expect(created).toBeDefined();
+    expect(
+      (created?.details as { customRoleName?: string } | undefined)
+        ?.customRoleName,
+    ).toBe("Audited Role");
+  });
+});
+
+describe("customRoles: updateCustomRoleDefinition", () => {
+  it("updates permissions and reports permissionsChanged=true", async () => {
+    const t = convexTest(schema, modules);
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    const result = await t.mutation(
+      api.customRoles.updateCustomRoleDefinition,
+      {
+        customRoleId: id,
+        tenantId: TENANT_A,
+        permissions: ["docs:read", "docs:write"],
+        grantablePermissions: GRANTABLE,
+      },
+    );
+
+    expect(result.permissions).toEqual(["docs:read", "docs:write"]);
+    expect(result.permissionsChanged).toBe(true);
+
+    const fetched = await t.query(api.customRoles.getCustomRole, {
+      customRoleId: id,
+      tenantId: TENANT_A,
+    });
+    expect(fetched?.permissions).toEqual(["docs:read", "docs:write"]);
+  });
+
+  it("reports permissionsChanged=false for set-equal updates", async () => {
+    const t = convexTest(schema, modules);
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read", "docs:write"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    const result = await t.mutation(
+      api.customRoles.updateCustomRoleDefinition,
+      {
+        customRoleId: id,
+        tenantId: TENANT_A,
+        permissions: ["docs:write", "docs:read"], // reordered
+        grantablePermissions: GRANTABLE,
+      },
+    );
+
+    expect(result.permissionsChanged).toBe(false);
+  });
+
+  it("rejects updates that introduce non-grantable permissions", async () => {
+    const t = convexTest(schema, modules);
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    await expect(
+      t.mutation(api.customRoles.updateCustomRoleDefinition, {
+        customRoleId: id,
+        tenantId: TENANT_A,
+        permissions: ["docs:read", "system:*"],
+        grantablePermissions: GRANTABLE,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("rejects cross-tenant update attempts as not-found", async () => {
+    const t = convexTest(schema, modules);
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    await expect(
+      t.mutation(api.customRoles.updateCustomRoleDefinition, {
+        customRoleId: id,
+        tenantId: TENANT_B, // wrong tenant
+        permissions: ["docs:write"],
+        grantablePermissions: GRANTABLE,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("rejects renaming to an existing name in the tenant", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Taken",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Original",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    await expect(
+      t.mutation(api.customRoles.updateCustomRoleDefinition, {
+        customRoleId: id,
+        tenantId: TENANT_A,
+        name: "Taken",
+        grantablePermissions: GRANTABLE,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
+describe("customRoles: deleteCustomRole", () => {
+  it("deletes a role with no assignments", async () => {
+    const t = convexTest(schema, modules);
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    const result = await t.mutation(api.customRoles.deleteCustomRole, {
+      customRoleId: id,
+      tenantId: TENANT_A,
+    });
+
+    expect(result.deleted).toBe(true);
+    expect(result.assignmentsRevoked).toBe(0);
+
+    const fetched = await t.query(api.customRoles.getCustomRole, {
+      customRoleId: id,
+      tenantId: TENANT_A,
+    });
+    expect(fetched).toBeNull();
+  });
+
+  it("refuses to delete a role with active assignments without force", async () => {
+    const t = convexTest(schema, modules);
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: TENANT_A,
+      userId: "user1",
+      role: customRoleStringFromId(id),
+      rolePermissions: ["docs:read"],
+    });
+
+    await expect(
+      t.mutation(api.customRoles.deleteCustomRole, {
+        customRoleId: id,
+        tenantId: TENANT_A,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("force-deletes a role and cleans up effective rows", async () => {
+    const t = convexTest(schema, modules);
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    const roleString = customRoleStringFromId(id);
+
+    await t.mutation(api.unified.assignRoleUnified, {
+      tenantId: TENANT_A,
+      userId: "user1",
+      role: roleString,
+      rolePermissions: ["docs:read"],
+    });
+
+    const result = await t.mutation(api.customRoles.deleteCustomRole, {
+      customRoleId: id,
+      tenantId: TENANT_A,
+      force: true,
+    });
+
+    expect(result.deleted).toBe(true);
+    expect(result.assignmentsRevoked).toBe(1);
+    expect(result.effectiveRolesRemoved).toBeGreaterThanOrEqual(1);
+
+    // Permission check should now deny
+    const allowed = await t.query(api.unified.checkPermission, {
+      tenantId: TENANT_A,
+      userId: "user1",
+      permission: "docs:read",
+    });
+    expect(allowed.allowed).toBe(false);
+  });
+
+  it("rejects cross-tenant delete attempts as not-found", async () => {
+    const t = convexTest(schema, modules);
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    await expect(
+      t.mutation(api.customRoles.deleteCustomRole, {
+        customRoleId: id,
+        tenantId: TENANT_B,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+});
+
+describe("customRoles: queries", () => {
+  it("listCustomRoles paginates by tenant", async () => {
+    const t = convexTest(schema, modules);
+
+    for (let i = 0; i < 5; i++) {
+      await t.mutation(api.customRoles.createCustomRole, {
+        tenantId: TENANT_A,
+        name: `Role ${i}`,
+        permissions: ["docs:read"],
+        createdBy: ADMIN_USER,
+        grantablePermissions: GRANTABLE,
+      });
+    }
+    await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_B,
+      name: "Other tenant role",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    const page = await t.query(api.customRoles.listCustomRoles, {
+      tenantId: TENANT_A,
+      paginationOpts: { numItems: 100, cursor: null },
+    });
+    expect(page.page).toHaveLength(5);
+    for (const row of page.page) {
+      expect(row.tenantId).toBe(TENANT_A);
+    }
+  });
+
+  it("getCustomRole returns null for cross-tenant lookups", async () => {
+    const t = convexTest(schema, modules);
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    const fromB = await t.query(api.customRoles.getCustomRole, {
+      customRoleId: id,
+      tenantId: TENANT_B,
+    });
+    expect(fromB).toBeNull();
+  });
+
+  it("getCustomRoleByName looks up by tenant + name", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    const fetched = await t.query(api.customRoles.getCustomRoleByName, {
+      tenantId: TENANT_A,
+      name: "Editor",
+    });
+    expect(fetched).not.toBeNull();
+    expect(fetched?.name).toBe("Editor");
+
+    const inB = await t.query(api.customRoles.getCustomRoleByName, {
+      tenantId: TENANT_B,
+      name: "Editor",
+    });
+    expect(inB).toBeNull();
+  });
+
+  it("countCustomRoles returns the count for a tenant", async () => {
+    const t = convexTest(schema, modules);
+
+    for (let i = 0; i < 3; i++) {
+      await t.mutation(api.customRoles.createCustomRole, {
+        tenantId: TENANT_A,
+        name: `Role ${i}`,
+        permissions: ["docs:read"],
+        createdBy: ADMIN_USER,
+        grantablePermissions: GRANTABLE,
+      });
+    }
+
+    expect(
+      await t.query(api.customRoles.countCustomRoles, { tenantId: TENANT_A }),
+    ).toBe(3);
+    expect(
+      await t.query(api.customRoles.countCustomRoles, { tenantId: TENANT_B }),
+    ).toBe(0);
+  });
+
+  it("getCustomRolePermissions returns name + permissions for the assigner", async () => {
+    const t = convexTest(schema, modules);
+
+    const id = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read", "docs:write"],
+      createdBy: ADMIN_USER,
+      grantablePermissions: GRANTABLE,
+    });
+
+    const result = await t.query(api.customRoles.getCustomRolePermissions, {
+      customRoleId: id,
+      tenantId: TENANT_A,
+    });
+    expect(result).toEqual({
+      name: "Editor",
+      permissions: ["docs:read", "docs:write"],
+    });
+
+    const crossTenant = await t.query(
+      api.customRoles.getCustomRolePermissions,
+      {
+        customRoleId: id,
+        tenantId: TENANT_B,
+      },
+    );
+    expect(crossTenant).toBeNull();
+  });
+});

--- a/src/component/tests/issue-31-custom-roles.test.ts
+++ b/src/component/tests/issue-31-custom-roles.test.ts
@@ -1,0 +1,466 @@
+/**
+ * End-to-end scenario tests for issue #31 — tenant-defined custom roles.
+ *
+ * Verifies the full lifecycle (create → assign → can() → update + cascade →
+ * revoke → delete) plus cross-tenant isolation invariants. This file
+ * complements the unit tests in:
+ *   - customRoles.test.ts          (CRUD + whitelist + cap)
+ *   - customRoleAssignment.test.ts (assign/revoke + composition)
+ *   - customRoleCascade.test.ts    (update fan-out + recompute correctness)
+ *   - tenant-isolation.test.ts     (existing system-role tenant isolation)
+ *
+ * Treat as the "do these all work together?" smoke suite for the feature.
+ */
+
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { ConvexError } from "convex/values";
+import schema from "../schema.js";
+import { api } from "../_generated/api.js";
+import { customRoleStringFromId } from "../customRoles.js";
+
+const modules = import.meta.glob("../**/*.ts");
+
+const TENANT_A = "tenant-acme";
+const TENANT_B = "tenant-globex";
+const ADMIN_A = "admin-A";
+const ADMIN_B = "admin-B";
+const GRANTABLE = ["docs:read", "docs:write", "docs:delete"];
+
+describe("issue #31 — custom roles end-to-end", () => {
+  it("full lifecycle in a single tenant: create → assign → can → update → revoke → delete", async () => {
+    const t = convexTest(schema, modules);
+
+    // 1. Create
+    const roleId = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_A,
+      grantablePermissions: GRANTABLE,
+      enableAudit: true,
+    });
+
+    // 2. Assign to user
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: "u1",
+      customRoleId: roleId,
+      assignedBy: ADMIN_A,
+      enableAudit: true,
+    });
+
+    // 3. can() works
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: "u1",
+          permission: "docs:read",
+        })
+      ).allowed,
+    ).toBe(true);
+
+    // 4. Update — add docs:write
+    const result = await t.action(api.customRoles.updateCustomRoleAction, {
+      tenantId: TENANT_A,
+      customRoleId: roleId,
+      permissions: ["docs:read", "docs:write"],
+      grantablePermissions: GRANTABLE,
+      rolePermissionsMap: {},
+      actorId: ADMIN_A,
+      enableAudit: true,
+    });
+    expect(result.permissionsChanged).toBe(true);
+    expect(result.usersRecomputed).toBe(1);
+
+    // 4a. New permission applied
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: "u1",
+          permission: "docs:write",
+        })
+      ).allowed,
+    ).toBe(true);
+
+    // 5. Revoke
+    expect(
+      await t.mutation(api.unified.revokeCustomRoleUnified, {
+        tenantId: TENANT_A,
+        userId: "u1",
+        customRoleId: roleId,
+        revokedBy: ADMIN_A,
+        enableAudit: true,
+      }),
+    ).toBe(true);
+
+    // 5a. Permissions gone
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: "u1",
+          permission: "docs:write",
+        })
+      ).allowed,
+    ).toBe(false);
+
+    // 6. Delete (no users hold it now → no force needed)
+    const del = await t.mutation(api.customRoles.deleteCustomRole, {
+      customRoleId: roleId,
+      tenantId: TENANT_A,
+      actorId: ADMIN_A,
+      enableAudit: true,
+    });
+    expect(del.deleted).toBe(true);
+    expect(del.assignmentsRevoked).toBe(0);
+
+    // 7. Audit log carries the full lifecycle
+    const logsResult = await t.query(api.queries.getAuditLog, {
+      tenantId: TENANT_A,
+    });
+    const logs = Array.isArray(logsResult) ? logsResult : logsResult.page;
+    const actions = logs.map((l) => l.action);
+    expect(actions).toContain("custom_role_created");
+    expect(actions).toContain("role_assigned");
+    expect(actions).toContain("custom_role_updated");
+    expect(actions).toContain("role_revoked");
+    expect(actions).toContain("custom_role_deleted");
+  });
+
+  it("custom roles in tenant A are invisible to tenant B", async () => {
+    const t = convexTest(schema, modules);
+
+    const aId = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read", "docs:write"],
+      createdBy: ADMIN_A,
+      grantablePermissions: GRANTABLE,
+    });
+
+    // Direct lookup from B returns null
+    expect(
+      await t.query(api.customRoles.getCustomRole, {
+        customRoleId: aId,
+        tenantId: TENANT_B,
+      }),
+    ).toBeNull();
+
+    // List from B is empty
+    const listB = await t.query(api.customRoles.listCustomRoles, {
+      tenantId: TENANT_B,
+      paginationOpts: { numItems: 100, cursor: null },
+    });
+    expect(listB.page).toHaveLength(0);
+
+    // Same name lookup in B returns null
+    expect(
+      await t.query(api.customRoles.getCustomRoleByName, {
+        tenantId: TENANT_B,
+        name: "Editor",
+      }),
+    ).toBeNull();
+  });
+
+  it("assigning tenant A's custom role from tenant B context throws", async () => {
+    const t = convexTest(schema, modules);
+
+    const aId = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_A,
+      grantablePermissions: GRANTABLE,
+    });
+
+    await expect(
+      t.mutation(api.unified.assignCustomRoleUnified, {
+        tenantId: TENANT_B,
+        userId: "u1",
+        customRoleId: aId,
+      }),
+    ).rejects.toThrow(ConvexError);
+  });
+
+  it("identical role names in different tenants are independent", async () => {
+    const t = convexTest(schema, modules);
+
+    const aId = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_A,
+      grantablePermissions: GRANTABLE,
+    });
+    const bId = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_B,
+      name: "Editor", // same name, different tenant
+      permissions: ["docs:read", "docs:write"], // different permissions
+      createdBy: ADMIN_B,
+      grantablePermissions: GRANTABLE,
+    });
+
+    expect(aId).not.toBe(bId);
+
+    // Each user gets the right permissions
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: "alice",
+      customRoleId: aId,
+    });
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_B,
+      userId: "bob",
+      customRoleId: bId,
+    });
+
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: "alice",
+          permission: "docs:write",
+        })
+      ).allowed,
+    ).toBe(false); // alice's "Editor" doesn't grant write
+
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_B,
+          userId: "bob",
+          permission: "docs:write",
+        })
+      ).allowed,
+    ).toBe(true); // bob's "Editor" does
+  });
+
+  it("update in tenant A does not affect users in tenant B", async () => {
+    const t = convexTest(schema, modules);
+
+    const aId = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_A,
+      grantablePermissions: GRANTABLE,
+    });
+    const bId = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_B,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_B,
+      grantablePermissions: GRANTABLE,
+    });
+
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: "alice",
+      customRoleId: aId,
+    });
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_B,
+      userId: "bob",
+      customRoleId: bId,
+    });
+
+    // Add docs:write to tenant A's role only
+    await t.action(api.customRoles.updateCustomRoleAction, {
+      tenantId: TENANT_A,
+      customRoleId: aId,
+      permissions: ["docs:read", "docs:write"],
+      grantablePermissions: GRANTABLE,
+      rolePermissionsMap: {},
+    });
+
+    // alice gets the new permission
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: "alice",
+          permission: "docs:write",
+        })
+      ).allowed,
+    ).toBe(true);
+
+    // bob does NOT — his tenant's "Editor" was untouched
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_B,
+          userId: "bob",
+          permission: "docs:write",
+        })
+      ).allowed,
+    ).toBe(false);
+  });
+
+  it("force-deleting a role in tenant A does not affect tenant B's same-named role", async () => {
+    const t = convexTest(schema, modules);
+
+    const aId = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_A,
+      grantablePermissions: GRANTABLE,
+    });
+    const bId = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_B,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_B,
+      grantablePermissions: GRANTABLE,
+    });
+
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: "alice",
+      customRoleId: aId,
+    });
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_B,
+      userId: "bob",
+      customRoleId: bId,
+    });
+
+    // Force-delete tenant A's role
+    await t.mutation(api.customRoles.deleteCustomRole, {
+      customRoleId: aId,
+      tenantId: TENANT_A,
+      force: true,
+    });
+
+    // alice loses access; bob keeps it
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: "alice",
+          permission: "docs:read",
+        })
+      ).allowed,
+    ).toBe(false);
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_B,
+          userId: "bob",
+          permission: "docs:read",
+        })
+      ).allowed,
+    ).toBe(true);
+
+    // tenant B's role still exists
+    expect(
+      await t.query(api.customRoles.getCustomRole, {
+        customRoleId: bId,
+        tenantId: TENANT_B,
+      }),
+    ).not.toBeNull();
+  });
+
+  it("listCustomRoles paginates correctly with multiple tenants present", async () => {
+    const t = convexTest(schema, modules);
+
+    for (let i = 0; i < 12; i++) {
+      await t.mutation(api.customRoles.createCustomRole, {
+        tenantId: TENANT_A,
+        name: `Role A-${i}`,
+        permissions: ["docs:read"],
+        createdBy: ADMIN_A,
+        grantablePermissions: GRANTABLE,
+      });
+    }
+    for (let i = 0; i < 5; i++) {
+      await t.mutation(api.customRoles.createCustomRole, {
+        tenantId: TENANT_B,
+        name: `Role B-${i}`,
+        permissions: ["docs:read"],
+        createdBy: ADMIN_B,
+        grantablePermissions: GRANTABLE,
+      });
+    }
+
+    // First page from tenant A — only tenant-A rows
+    const pageA1 = await t.query(api.customRoles.listCustomRoles, {
+      tenantId: TENANT_A,
+      paginationOpts: { numItems: 5, cursor: null },
+    });
+    expect(pageA1.page).toHaveLength(5);
+    for (const row of pageA1.page) expect(row.tenantId).toBe(TENANT_A);
+
+    // Walk to the end of tenant A's pages — total should be 12
+    let cursor: string | null = pageA1.continueCursor;
+    let total = pageA1.page.length;
+    while (true) {
+      const next = await t.query(api.customRoles.listCustomRoles, {
+        tenantId: TENANT_A,
+        paginationOpts: { numItems: 5, cursor },
+      });
+      total += next.page.length;
+      for (const row of next.page) expect(row.tenantId).toBe(TENANT_A);
+      if (next.isDone) break;
+      cursor = next.continueCursor;
+    }
+    expect(total).toBe(12);
+
+    // Counts agree
+    expect(
+      await t.query(api.customRoles.countCustomRoles, { tenantId: TENANT_A }),
+    ).toBe(12);
+    expect(
+      await t.query(api.customRoles.countCustomRoles, { tenantId: TENANT_B }),
+    ).toBe(5);
+  });
+
+  it("namespaced role string is stable across tenants — collision is not possible", async () => {
+    const t = convexTest(schema, modules);
+
+    const aId = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_A,
+      grantablePermissions: GRANTABLE,
+    });
+    const bId = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_B,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: ADMIN_B,
+      grantablePermissions: GRANTABLE,
+    });
+
+    // Different ids → different namespaced role strings
+    expect(customRoleStringFromId(aId)).not.toBe(customRoleStringFromId(bId));
+
+    // hasRole only matches inside its own tenant
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: "alice",
+      customRoleId: aId,
+    });
+
+    expect(
+      await t.query(api.indexed.hasRoleFast, {
+        tenantId: TENANT_A,
+        userId: "alice",
+        role: customRoleStringFromId(aId),
+      }),
+    ).toBe(true);
+
+    // Same role string lookup in TENANT_B is false (no assignment there)
+    expect(
+      await t.query(api.indexed.hasRoleFast, {
+        tenantId: TENANT_B,
+        userId: "alice",
+        role: customRoleStringFromId(aId),
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/component/tests/issue-31-custom-roles.test.ts
+++ b/src/component/tests/issue-31-custom-roles.test.ts
@@ -397,14 +397,18 @@ describe("issue #31 — custom roles end-to-end", () => {
     // Walk to the end of tenant A's pages — total should be 12
     let cursor: string | null = pageA1.continueCursor;
     let total = pageA1.page.length;
-    while (true) {
-      const next = await t.query(api.customRoles.listCustomRoles, {
-        tenantId: TENANT_A,
-        paginationOpts: { numItems: 5, cursor },
-      });
+    let isDone = pageA1.isDone;
+    while (!isDone) {
+      const next: typeof pageA1 = await t.query(
+        api.customRoles.listCustomRoles,
+        {
+          tenantId: TENANT_A,
+          paginationOpts: { numItems: 5, cursor },
+        },
+      );
       total += next.page.length;
       for (const row of next.page) expect(row.tenantId).toBe(TENANT_A);
-      if (next.isDone) break;
+      isDone = next.isDone;
       cursor = next.continueCursor;
     }
     expect(total).toBe(12);

--- a/src/component/unified.ts
+++ b/src/component/unified.ts
@@ -1433,6 +1433,10 @@ export const recomputeUser = mutation({
       .take(4000);
 
     // ── Step 4: Rebuild effectiveRoles and effectivePermissions ──────────
+    // Cache resolved custom role permissions to avoid repeated lookups when a
+    // user holds the same custom role in multiple scopes.
+    const customRolePermsCache = new Map<string, string[]>();
+
     for (const assignment of roleAssignments) {
       // Skip expired assignments
       if (assignment.expiresAt !== undefined && assignment.expiresAt < now) {
@@ -1456,8 +1460,26 @@ export const recomputeUser = mutation({
         updatedAt: now,
       });
 
-      // Look up permissions for this role from rolePermissionsMap
-      const permissions = args.rolePermissionsMap[assignment.role] ?? [];
+      // Look up permissions for this role. System roles come from the caller-
+      // supplied map. Custom roles ("custom:<id>") are resolved against the
+      // customRoles table directly so callers don't have to pre-build a map
+      // that includes every tenant's custom roles.
+      let permissions: string[];
+      if (assignment.role.startsWith("custom:")) {
+        if (customRolePermsCache.has(assignment.role)) {
+          permissions = customRolePermsCache.get(assignment.role)!;
+        } else {
+          const customRoleId = assignment.role.slice("custom:".length) as Id<"customRoles">;
+          const customRole = await ctx.db.get(customRoleId);
+          permissions =
+            customRole !== null && customRole.tenantId === args.tenantId
+              ? customRole.permissions
+              : [];
+          customRolePermsCache.set(assignment.role, permissions);
+        }
+      } else {
+        permissions = args.rolePermissionsMap[assignment.role] ?? [];
+      }
 
       for (const permission of permissions) {
         const classification = args.policyClassifications?.[permission] ?? null;

--- a/src/component/unified.ts
+++ b/src/component/unified.ts
@@ -14,6 +14,8 @@ import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { action, mutation, query } from "./_generated/server.js";
 import { api } from "./_generated/api.js";
+import type { MutationCtx } from "./_generated/server.js";
+import type { Id } from "./_generated/dataModel.js";
 import { scopeValidator } from "./validators.js";
 import { isExpired, matchesPermissionPattern } from "./helpers.js";
 import { paginator } from "convex-helpers/server/pagination";
@@ -31,6 +33,243 @@ function scopeEquals(
   if (a === undefined && b === undefined) return true;
   if (a === undefined || b === undefined) return false;
   return a.type === b.type && a.id === b.id;
+}
+
+type PolicyClassification = "allow" | "deny" | "deferred" | null;
+
+/**
+ * Inputs to the dual-write helpers below. Both system-role and custom-role
+ * assignments funnel through these — the only difference is what `role`
+ * looks like ("admin" vs. "custom:abc123") and where `rolePermissions`
+ * came from.
+ */
+type AssignmentInputs = {
+  tenantId: string;
+  userId: string;
+  role: string;
+  rolePermissions: string[];
+  scope: { type: string; id: string } | undefined;
+  scopeKey: string;
+  expiresAt: number | undefined;
+  assignedBy: string | undefined;
+  metadata: unknown;
+  policyClassifications:
+    | Record<string, PolicyClassification>
+    | undefined;
+  now: number;
+};
+
+/**
+ * If a non-expired assignment for (tenant, user, role, scope) already exists,
+ * extend its expiry to `args.expiresAt` (no-op if the new expiry is shorter)
+ * and dual-write the new expiry into `effectiveRoles` and the matching
+ * `effectivePermissions` rows. Returns the existing assignment id.
+ *
+ * Returns null when no duplicate is present and the caller should proceed to
+ * `writeNewAssignment`.
+ *
+ * Extracted from the historic inline duplicate-detection logic so that
+ * `assignRoleUnified`, `assignRolesUnified`, and `assignCustomRoleUnified`
+ * can share a single source of truth for idempotency semantics.
+ */
+async function tryExtendExistingAssignment(
+  ctx: MutationCtx,
+  args: AssignmentInputs,
+): Promise<Id<"roleAssignments"> | null> {
+  const existing = await ctx.db
+    .query("roleAssignments")
+    .withIndex("by_tenant_user_and_role", (q) =>
+      q
+        .eq("tenantId", args.tenantId)
+        .eq("userId", args.userId)
+        .eq("role", args.role),
+    )
+    .take(100);
+
+  for (const row of existing) {
+    if (!scopeEquals(row.scope, args.scope) || isExpired(row.expiresAt)) {
+      continue;
+    }
+
+    // Extend expiry: only update if new value is later or removes expiry entirely.
+    // Passing a shorter expiresAt is a no-op (prevents accidental expiry reduction).
+    // To shorten expiry, revoke and re-assign.
+    const shouldExtend =
+      args.expiresAt === undefined ||
+      (row.expiresAt !== undefined && args.expiresAt > row.expiresAt);
+    if (!shouldExtend || args.expiresAt === row.expiresAt) {
+      return row._id;
+    }
+
+    const newExpiry = args.expiresAt;
+
+    // 1. Source row
+    await ctx.db.patch(row._id, { expiresAt: newExpiry });
+
+    // 2. effectiveRoles
+    const effRole = await ctx.db
+      .query("effectiveRoles")
+      .withIndex("by_tenant_user_role_scope", (q) =>
+        q
+          .eq("tenantId", args.tenantId)
+          .eq("userId", args.userId)
+          .eq("role", args.role)
+          .eq("scopeKey", args.scopeKey),
+      )
+      .unique();
+    if (effRole) {
+      await ctx.db.patch(effRole._id, {
+        expiresAt: newExpiry,
+        updatedAt: args.now,
+      });
+    }
+
+    // 3. effectivePermissions where this role is one of the sources
+    for (const permission of args.rolePermissions) {
+      const effPerm = await ctx.db
+        .query("effectivePermissions")
+        .withIndex("by_tenant_user_permission_scope", (q) =>
+          q
+            .eq("tenantId", args.tenantId)
+            .eq("userId", args.userId)
+            .eq("permission", permission)
+            .eq("scopeKey", args.scopeKey),
+        )
+        .unique();
+      if (effPerm && effPerm.sources.includes(args.role)) {
+        const mergedExpiry =
+          effPerm.expiresAt === undefined || newExpiry === undefined
+            ? undefined
+            : Math.max(effPerm.expiresAt, newExpiry);
+        await ctx.db.patch(effPerm._id, {
+          expiresAt: mergedExpiry,
+          updatedAt: args.now,
+        });
+      }
+    }
+
+    return row._id;
+  }
+
+  return null;
+}
+
+/**
+ * Insert a fresh `roleAssignments` row and dual-write into `effectiveRoles`
+ * + `effectivePermissions`. Caller must have already confirmed (via
+ * `tryExtendExistingAssignment`) that no live duplicate exists.
+ */
+async function writeNewAssignment(
+  ctx: MutationCtx,
+  args: AssignmentInputs,
+): Promise<Id<"roleAssignments">> {
+  // 1. Source of truth
+  const assignmentId = await ctx.db.insert("roleAssignments", {
+    tenantId: args.tenantId,
+    userId: args.userId,
+    role: args.role,
+    scope: args.scope,
+    expiresAt: args.expiresAt,
+    assignedBy: args.assignedBy,
+    metadata: args.metadata,
+  });
+
+  // 2. effectiveRoles upsert
+  const existingEffectiveRole = await ctx.db
+    .query("effectiveRoles")
+    .withIndex("by_tenant_user_role_scope", (q) =>
+      q
+        .eq("tenantId", args.tenantId)
+        .eq("userId", args.userId)
+        .eq("role", args.role)
+        .eq("scopeKey", args.scopeKey),
+    )
+    .unique();
+
+  if (existingEffectiveRole) {
+    await ctx.db.patch(existingEffectiveRole._id, {
+      assignedBy: args.assignedBy,
+      expiresAt: args.expiresAt,
+      updatedAt: args.now,
+    });
+  } else {
+    await ctx.db.insert("effectiveRoles", {
+      tenantId: args.tenantId,
+      userId: args.userId,
+      role: args.role,
+      scopeKey: args.scopeKey,
+      scope: args.scope,
+      assignedBy: args.assignedBy,
+      expiresAt: args.expiresAt,
+      createdAt: args.now,
+      updatedAt: args.now,
+    });
+  }
+
+  // 3. effectivePermissions: one row per granted permission, with this role
+  //    appended to `sources` (or inserted fresh).
+  for (const permission of args.rolePermissions) {
+    const classification =
+      args.policyClassifications?.[permission] ?? null;
+
+    // Skip permissions where policy evaluated to "deny"
+    if (classification === "deny") continue;
+
+    const existingPerm = await ctx.db
+      .query("effectivePermissions")
+      .withIndex("by_tenant_user_permission_scope", (q) =>
+        q
+          .eq("tenantId", args.tenantId)
+          .eq("userId", args.userId)
+          .eq("permission", permission)
+          .eq("scopeKey", args.scopeKey),
+      )
+      .unique();
+
+    if (existingPerm) {
+      const sources = existingPerm.sources.includes(args.role)
+        ? existingPerm.sources
+        : [...existingPerm.sources, args.role];
+      const patchData: Record<string, unknown> = {
+        sources,
+        updatedAt: args.now,
+      };
+      if (classification === "deferred" && !existingPerm.policyResult) {
+        patchData.policyResult = "deferred";
+        patchData.policyName = permission;
+      } else if (classification === "allow" && !existingPerm.policyResult) {
+        patchData.policyResult = "allow";
+      }
+      // Merged expiresAt: no-expiry (undefined) wins over any expiry
+      const existingExpiry = existingPerm.expiresAt;
+      const newExpiry = args.expiresAt;
+      patchData.expiresAt =
+        existingExpiry === undefined || newExpiry === undefined
+          ? undefined
+          : Math.max(existingExpiry, newExpiry);
+      await ctx.db.patch(existingPerm._id, patchData);
+    } else {
+      await ctx.db.insert("effectivePermissions", {
+        tenantId: args.tenantId,
+        userId: args.userId,
+        permission,
+        scopeKey: args.scopeKey,
+        scope: args.scope,
+        effect: "allow",
+        sources: [args.role],
+        expiresAt: args.expiresAt,
+        createdAt: args.now,
+        updatedAt: args.now,
+        ...(classification === "deferred"
+          ? { policyResult: "deferred" as const, policyName: permission }
+          : classification === "allow"
+            ? { policyResult: "allow" as const }
+            : {}),
+      });
+    }
+  }
+
+  return assignmentId;
 }
 
 export const checkPermission = query({
@@ -238,182 +477,29 @@ export const assignRoleUnified = mutation({
   returns: v.string(),
   handler: async (ctx, args) => {
     const now = Date.now();
-
-    // 1. Compute scopeKey
     const scopeKey = args.scope
       ? `${args.scope.type}:${args.scope.id}`
       : "global";
-
-    // 2. Check for duplicate in roleAssignments
-    const existing = await ctx.db
-      .query("roleAssignments")
-      .withIndex("by_tenant_user_and_role", (q) =>
-        q
-          .eq("tenantId", args.tenantId)
-          .eq("userId", args.userId)
-          .eq("role", args.role)
-      )
-      .take(100);
-
-    for (const row of existing) {
-      if (scopeEquals(row.scope, args.scope) && !isExpired(row.expiresAt)) {
-        // Extend expiry: only update if new value is later or removes expiry entirely.
-        // Passing a shorter expiresAt is a no-op (prevents accidental expiry reduction).
-        // To shorten expiry, revoke and re-assign.
-        const shouldExtend = args.expiresAt === undefined ||
-          (row.expiresAt !== undefined && args.expiresAt > row.expiresAt);
-        if (shouldExtend && args.expiresAt !== row.expiresAt) {
-          const newExpiry = args.expiresAt;
-          // 1. Update source table
-          await ctx.db.patch(row._id, { expiresAt: newExpiry });
-          // 2. Update effectiveRoles
-          const scopeKey = args.scope
-            ? `${args.scope.type}:${args.scope.id}`
-            : "global";
-          const effRole = await ctx.db
-            .query("effectiveRoles")
-            .withIndex("by_tenant_user_role_scope", (q) =>
-              q.eq("tenantId", args.tenantId)
-                .eq("userId", args.userId)
-                .eq("role", args.role)
-                .eq("scopeKey", scopeKey)
-            )
-            .unique();
-          if (effRole) {
-            await ctx.db.patch(effRole._id, { expiresAt: newExpiry, updatedAt: Date.now() });
-          }
-          // 3. Update effectivePermissions for this role's permissions
-          for (const permission of args.rolePermissions) {
-            const effPerm = await ctx.db
-              .query("effectivePermissions")
-              .withIndex("by_tenant_user_permission_scope", (q) =>
-                q.eq("tenantId", args.tenantId)
-                  .eq("userId", args.userId)
-                  .eq("permission", permission)
-                  .eq("scopeKey", scopeKey)
-              )
-              .unique();
-            if (effPerm && effPerm.sources.includes(args.role)) {
-              // Recompute merged expiresAt considering all sources
-              // Since we can't cheaply check all other sources' expiry,
-              // just set to the new (extended) value
-              const mergedExpiry = effPerm.expiresAt === undefined ? undefined
-                : newExpiry === undefined ? undefined
-                : Math.max(effPerm.expiresAt, newExpiry);
-              await ctx.db.patch(effPerm._id, { expiresAt: mergedExpiry, updatedAt: Date.now() });
-            }
-          }
-        }
-        return row._id;
-      }
-    }
-
-    // 3. Insert into roleAssignments (source of truth)
-    const assignmentId = await ctx.db.insert("roleAssignments", {
+    const inputs: AssignmentInputs = {
       tenantId: args.tenantId,
       userId: args.userId,
       role: args.role,
+      rolePermissions: args.rolePermissions,
       scope: args.scope,
+      scopeKey,
       expiresAt: args.expiresAt,
       assignedBy: args.assignedBy,
       metadata: args.metadata,
-    });
+      policyClassifications: args.policyClassifications,
+      now,
+    };
 
-    // 4. Upsert into effectiveRoles
-    const existingEffectiveRole = await ctx.db
-      .query("effectiveRoles")
-      .withIndex("by_tenant_user_role_scope", (q) =>
-        q
-          .eq("tenantId", args.tenantId)
-          .eq("userId", args.userId)
-          .eq("role", args.role)
-          .eq("scopeKey", scopeKey)
-      )
-      .unique();
+    // Idempotent re-assign: extend the existing assignment's expiry if any.
+    const existingId = await tryExtendExistingAssignment(ctx, inputs);
+    if (existingId !== null) return existingId;
 
-    if (existingEffectiveRole) {
-      await ctx.db.patch(existingEffectiveRole._id, {
-        assignedBy: args.assignedBy,
-        expiresAt: args.expiresAt,
-        updatedAt: now,
-      });
-    } else {
-      await ctx.db.insert("effectiveRoles", {
-        tenantId: args.tenantId,
-        userId: args.userId,
-        role: args.role,
-        scopeKey,
-        scope: args.scope,
-        assignedBy: args.assignedBy,
-        expiresAt: args.expiresAt,
-        createdAt: now,
-        updatedAt: now,
-      });
-    }
+    const assignmentId = await writeNewAssignment(ctx, inputs);
 
-    // 5. Process each permission in rolePermissions
-    for (const permission of args.rolePermissions) {
-      const classification = args.policyClassifications?.[permission] ?? null;
-
-      // Skip permissions where policy evaluated to "deny"
-      if (classification === "deny") {
-        continue;
-      }
-
-      const existingPerm = await ctx.db
-        .query("effectivePermissions")
-        .withIndex("by_tenant_user_permission_scope", (q) =>
-          q
-            .eq("tenantId", args.tenantId)
-            .eq("userId", args.userId)
-            .eq("permission", permission)
-            .eq("scopeKey", scopeKey)
-        )
-        .unique();
-
-      if (existingPerm) {
-        // Add role to sources if not already present
-        const sources = existingPerm.sources.includes(args.role)
-          ? existingPerm.sources
-          : [...existingPerm.sources, args.role];
-        // Also update policyResult if the new classification is more specific
-        const patchData: Record<string, unknown> = { sources, updatedAt: now };
-        if (classification === "deferred" && !existingPerm.policyResult) {
-          patchData.policyResult = "deferred";
-          patchData.policyName = permission;
-        } else if (classification === "allow" && !existingPerm.policyResult) {
-          patchData.policyResult = "allow";
-        }
-        // Compute merged expiresAt: no-expiry (undefined) wins over any expiry
-        const existingExpiry = existingPerm.expiresAt;
-        const newExpiry = args.expiresAt;
-        const mergedExpiresAt = existingExpiry === undefined || newExpiry === undefined
-          ? undefined
-          : Math.max(existingExpiry, newExpiry);
-        patchData.expiresAt = mergedExpiresAt;
-        await ctx.db.patch(existingPerm._id, patchData);
-      } else {
-        await ctx.db.insert("effectivePermissions", {
-          tenantId: args.tenantId,
-          userId: args.userId,
-          permission,
-          scopeKey,
-          scope: args.scope,
-          effect: "allow",
-          sources: [args.role],
-          expiresAt: args.expiresAt,
-          createdAt: now,
-          updatedAt: now,
-          ...(classification === "deferred"
-            ? { policyResult: "deferred", policyName: permission }
-            : classification === "allow"
-              ? { policyResult: "allow" }
-              : {}),
-        });
-      }
-    }
-
-    // 6. Audit log
     if (args.enableAudit) {
       await ctx.db.insert("auditLog", {
         tenantId: args.tenantId,
@@ -428,7 +514,6 @@ export const assignRoleUnified = mutation({
       });
     }
 
-    // 7. Return assignment ID
     return assignmentId;
   },
 });
@@ -1418,184 +1503,34 @@ export const assignRolesUnified = mutation({
     let assigned = 0;
 
     for (const item of args.roles) {
-      // 1. Compute scopeKey
       const scopeKey = item.scope
         ? `${item.scope.type}:${item.scope.id}`
         : "global";
 
-      // 2. Check for duplicate in roleAssignments
-      const existing = await ctx.db
-        .query("roleAssignments")
-        .withIndex("by_tenant_user_and_role", (q) =>
-          q
-            .eq("tenantId", args.tenantId)
-            .eq("userId", args.userId)
-            .eq("role", item.role)
-        )
-        .take(100);
-
-      let isDuplicate = false;
-      for (const row of existing) {
-        if (scopeEquals(row.scope, item.scope) && !isExpired(row.expiresAt)) {
-          // Extend expiry: only update if new value is later or removes expiry entirely.
-          // Passing a shorter expiresAt is a no-op (prevents accidental expiry reduction).
-          // To shorten expiry, revoke and re-assign.
-          const shouldExtend = item.expiresAt === undefined ||
-            (row.expiresAt !== undefined && item.expiresAt > row.expiresAt);
-          if (shouldExtend && item.expiresAt !== row.expiresAt) {
-            const newExpiry = item.expiresAt;
-            // Update source table
-            await ctx.db.patch(row._id, { expiresAt: newExpiry });
-            // Update effectiveRoles
-            const effRole = await ctx.db
-              .query("effectiveRoles")
-              .withIndex("by_tenant_user_role_scope", (q) =>
-                q.eq("tenantId", args.tenantId)
-                  .eq("userId", args.userId)
-                  .eq("role", item.role)
-                  .eq("scopeKey", scopeKey)
-              )
-              .unique();
-            if (effRole) {
-              await ctx.db.patch(effRole._id, { expiresAt: newExpiry, updatedAt: now });
-            }
-            // Update effectivePermissions for this role's permissions
-            const permissions = args.rolePermissionsMap[item.role] ?? [];
-            for (const permission of permissions) {
-              const effPerm = await ctx.db
-                .query("effectivePermissions")
-                .withIndex("by_tenant_user_permission_scope", (q) =>
-                  q.eq("tenantId", args.tenantId)
-                    .eq("userId", args.userId)
-                    .eq("permission", permission)
-                    .eq("scopeKey", scopeKey)
-                )
-                .unique();
-              if (effPerm && effPerm.sources.includes(item.role)) {
-                const mergedExpiry = effPerm.expiresAt === undefined ? undefined
-                  : newExpiry === undefined ? undefined
-                  : Math.max(effPerm.expiresAt, newExpiry);
-                await ctx.db.patch(effPerm._id, { expiresAt: mergedExpiry, updatedAt: now });
-              }
-            }
-          }
-          isDuplicate = true;
-          break;
-        }
-      }
-
-      if (isDuplicate) {
-        continue;
-      }
-
-      // 3. Insert into roleAssignments (source of truth)
-      const assignmentId = await ctx.db.insert("roleAssignments", {
+      const inputs: AssignmentInputs = {
         tenantId: args.tenantId,
         userId: args.userId,
         role: item.role,
+        rolePermissions: args.rolePermissionsMap[item.role] ?? [],
         scope: item.scope,
+        scopeKey,
         expiresAt: item.expiresAt,
         assignedBy: args.assignedBy,
         metadata: item.metadata,
-      });
+        policyClassifications: args.policyClassifications,
+        now,
+      };
+
+      // Idempotent re-assign: extend the existing assignment's expiry if any.
+      const existingId = await tryExtendExistingAssignment(ctx, inputs);
+      if (existingId !== null) {
+        continue;
+      }
+
+      const assignmentId = await writeNewAssignment(ctx, inputs);
       assignmentIds.push(assignmentId as string);
       assigned++;
 
-      // 4. Upsert into effectiveRoles
-      const existingEffectiveRole = await ctx.db
-        .query("effectiveRoles")
-        .withIndex("by_tenant_user_role_scope", (q) =>
-          q
-            .eq("tenantId", args.tenantId)
-            .eq("userId", args.userId)
-            .eq("role", item.role)
-            .eq("scopeKey", scopeKey)
-        )
-        .unique();
-
-      if (existingEffectiveRole) {
-        await ctx.db.patch(existingEffectiveRole._id, {
-          assignedBy: args.assignedBy,
-          expiresAt: item.expiresAt,
-          updatedAt: now,
-        });
-      } else {
-        await ctx.db.insert("effectiveRoles", {
-          tenantId: args.tenantId,
-          userId: args.userId,
-          role: item.role,
-          scopeKey,
-          scope: item.scope,
-          assignedBy: args.assignedBy,
-          expiresAt: item.expiresAt,
-          createdAt: now,
-          updatedAt: now,
-        });
-      }
-
-      // 5. Process each permission the role grants (from rolePermissionsMap)
-      const permissions = args.rolePermissionsMap[item.role] ?? [];
-      for (const permission of permissions) {
-        const classification = args.policyClassifications?.[permission] ?? null;
-
-        // Skip permissions where policy evaluated to "deny"
-        if (classification === "deny") {
-          continue;
-        }
-
-        const existingPerm = await ctx.db
-          .query("effectivePermissions")
-          .withIndex("by_tenant_user_permission_scope", (q) =>
-            q
-              .eq("tenantId", args.tenantId)
-              .eq("userId", args.userId)
-              .eq("permission", permission)
-              .eq("scopeKey", scopeKey)
-          )
-          .unique();
-
-        if (existingPerm) {
-          // Add role to sources if not already present
-          const sources = existingPerm.sources.includes(item.role)
-            ? existingPerm.sources
-            : [...existingPerm.sources, item.role];
-          const patchData: Record<string, unknown> = { sources, updatedAt: now };
-          if (classification === "deferred" && !existingPerm.policyResult) {
-            patchData.policyResult = "deferred";
-            patchData.policyName = permission;
-          } else if (classification === "allow" && !existingPerm.policyResult) {
-            patchData.policyResult = "allow";
-          }
-          // Compute merged expiresAt: no-expiry (undefined) wins over any expiry
-          const existingExpiry = existingPerm.expiresAt;
-          const newExpiry = item.expiresAt;
-          const mergedExpiresAt = existingExpiry === undefined || newExpiry === undefined
-            ? undefined
-            : Math.max(existingExpiry, newExpiry);
-          patchData.expiresAt = mergedExpiresAt;
-          await ctx.db.patch(existingPerm._id, patchData);
-        } else {
-          await ctx.db.insert("effectivePermissions", {
-            tenantId: args.tenantId,
-            userId: args.userId,
-            permission,
-            scopeKey,
-            scope: item.scope,
-            effect: "allow",
-            sources: [item.role],
-            expiresAt: item.expiresAt,
-            createdAt: now,
-            updatedAt: now,
-            ...(classification === "deferred"
-              ? { policyResult: "deferred", policyName: permission }
-              : classification === "allow"
-                ? { policyResult: "allow" }
-                : {}),
-          });
-        }
-      }
-
-      // 6. Audit log entry per role if enableAudit
       if (args.enableAudit) {
         await ctx.db.insert("auditLog", {
           tenantId: args.tenantId,

--- a/src/component/unified.ts
+++ b/src/component/unified.ts
@@ -10,7 +10,7 @@
  *   3. No match -> denied
  */
 
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { action, mutation, query } from "./_generated/server.js";
 import { api } from "./_generated/api.js";
@@ -152,6 +152,97 @@ async function tryExtendExistingAssignment(
   }
 
   return null;
+}
+
+/**
+ * Revoke a single (user, role, scope) assignment, dual-writing the deletion
+ * to `effectiveRoles` and removing this role from `effectivePermissions.sources`
+ * (deleting the row entirely when no other sources / direct grants remain).
+ *
+ * Returns true if a matching assignment was found and revoked, false if no
+ * such assignment existed.
+ */
+async function revokeAssignmentDualWrite(
+  ctx: MutationCtx,
+  args: {
+    tenantId: string;
+    userId: string;
+    role: string;
+    rolePermissions: string[];
+    scope: { type: string; id: string } | undefined;
+    scopeKey: string;
+    now: number;
+  },
+): Promise<boolean> {
+  const assignments = await ctx.db
+    .query("roleAssignments")
+    .withIndex("by_tenant_user_and_role", (q) =>
+      q
+        .eq("tenantId", args.tenantId)
+        .eq("userId", args.userId)
+        .eq("role", args.role),
+    )
+    .take(100);
+
+  const assignment = assignments.find((row) =>
+    scopeEquals(row.scope, args.scope),
+  );
+
+  if (!assignment) return false;
+
+  // 1. Source row
+  await ctx.db.delete(assignment._id);
+
+  // 2. effectiveRoles row
+  const effectiveRole = await ctx.db
+    .query("effectiveRoles")
+    .withIndex("by_tenant_user_role_scope", (q) =>
+      q
+        .eq("tenantId", args.tenantId)
+        .eq("userId", args.userId)
+        .eq("role", args.role)
+        .eq("scopeKey", args.scopeKey),
+    )
+    .unique();
+  if (effectiveRole) {
+    await ctx.db.delete(effectiveRole._id);
+  }
+
+  // 3. effectivePermissions: remove this role from sources, deleting the row
+  //    entirely if no other sources and no direct grant/deny remain.
+  for (const permission of args.rolePermissions) {
+    const effectivePerm = await ctx.db
+      .query("effectivePermissions")
+      .withIndex("by_tenant_user_permission_scope", (q) =>
+        q
+          .eq("tenantId", args.tenantId)
+          .eq("userId", args.userId)
+          .eq("permission", permission)
+          .eq("scopeKey", args.scopeKey),
+      )
+      .unique();
+
+    if (!effectivePerm) continue;
+
+    const updatedSources = effectivePerm.sources.filter(
+      (s) => s !== args.role,
+    );
+
+    if (
+      updatedSources.length === 0 &&
+      !effectivePerm.directGrant &&
+      !effectivePerm.directDeny
+    ) {
+      await ctx.db.delete(effectivePerm._id);
+    } else if (updatedSources.length !== effectivePerm.sources.length) {
+      await ctx.db.patch(effectivePerm._id, {
+        sources: updatedSources,
+        updatedAt: args.now,
+      });
+    }
+  }
+
+  return true;
 }
 
 /**
@@ -537,82 +628,22 @@ export const revokeRoleUnified = mutation({
   returns: v.boolean(),
   handler: async (ctx, args) => {
     const now = Date.now();
-
-    // 1. Compute scopeKey
     const scopeKey = args.scope
       ? `${args.scope.type}:${args.scope.id}`
       : "global";
 
-    // 2. Find the role assignment in roleAssignments
-    const assignments = await ctx.db
-      .query("roleAssignments")
-      .withIndex("by_tenant_user_and_role", (q) =>
-        q
-          .eq("tenantId", args.tenantId)
-          .eq("userId", args.userId)
-          .eq("role", args.role)
-      )
-      .take(100);
+    const revoked = await revokeAssignmentDualWrite(ctx, {
+      tenantId: args.tenantId,
+      userId: args.userId,
+      role: args.role,
+      rolePermissions: args.rolePermissions,
+      scope: args.scope,
+      scopeKey,
+      now,
+    });
 
-    const assignment = assignments.find(
-      (row) => scopeEquals(row.scope, args.scope)
-    );
+    if (!revoked) return false;
 
-    if (!assignment) {
-      return false;
-    }
-
-    // 3. Delete from roleAssignments
-    await ctx.db.delete(assignment._id);
-
-    // 4. Delete from effectiveRoles
-    const effectiveRole = await ctx.db
-      .query("effectiveRoles")
-      .withIndex("by_tenant_user_role_scope", (q) =>
-        q
-          .eq("tenantId", args.tenantId)
-          .eq("userId", args.userId)
-          .eq("role", args.role)
-          .eq("scopeKey", scopeKey)
-      )
-      .unique();
-
-    if (effectiveRole) {
-      await ctx.db.delete(effectiveRole._id);
-    }
-
-    // 5. For each permission the revoked role granted, update effectivePermissions
-    for (const permission of args.rolePermissions) {
-      const effectivePerm = await ctx.db
-        .query("effectivePermissions")
-        .withIndex("by_tenant_user_permission_scope", (q) =>
-          q
-            .eq("tenantId", args.tenantId)
-            .eq("userId", args.userId)
-            .eq("permission", permission)
-            .eq("scopeKey", scopeKey)
-        )
-        .unique();
-
-      if (!effectivePerm) continue;
-
-      const updatedSources = effectivePerm.sources.filter(
-        (s) => s !== args.role
-      );
-
-      if (updatedSources.length === 0 && !effectivePerm.directGrant && !effectivePerm.directDeny) {
-        // No more sources, no direct grant, no direct deny — delete the row
-        await ctx.db.delete(effectivePerm._id);
-      } else if (updatedSources.length !== effectivePerm.sources.length) {
-        // Role was in sources; patch with updated array
-        await ctx.db.patch(effectivePerm._id, {
-          sources: updatedSources,
-          updatedAt: now,
-        });
-      }
-    }
-
-    // 6. Audit log
     if (args.enableAudit) {
       await ctx.db.insert("auditLog", {
         tenantId: args.tenantId,
@@ -627,7 +658,169 @@ export const revokeRoleUnified = mutation({
       });
     }
 
-    // 7. Return true
+    return true;
+  },
+});
+
+/**
+ * Unified Custom Role Assignment
+ *
+ * Assigns a tenant-defined custom role to a user. The custom role row is
+ * looked up first (validating tenant ownership), its snapshot permissions are
+ * read, and the same dual-write helpers used by `assignRoleUnified` do the
+ * rest. The role is stored in `roleAssignments.role` and `effectiveRoles.role`
+ * as the namespaced string `"custom:<id>"`, which keeps the read path
+ * (`hasRoleFast`, `checkPermissionFast`) treating system and custom roles
+ * identically.
+ *
+ * Throws `CUSTOM_ROLE_NOT_FOUND` if the role does not exist or belongs to a
+ * different tenant.
+ */
+export const assignCustomRoleUnified = mutation({
+  args: {
+    tenantId: v.string(),
+    userId: v.string(),
+    customRoleId: v.id("customRoles"),
+    scope: scopeValidator,
+    expiresAt: v.optional(v.number()),
+    assignedBy: v.optional(v.string()),
+    metadata: v.optional(v.any()),
+    enableAudit: v.optional(v.boolean()),
+    policyClassifications: v.optional(
+      v.record(
+        v.string(),
+        v.union(
+          v.null(),
+          v.literal("allow"),
+          v.literal("deny"),
+          v.literal("deferred"),
+        ),
+      ),
+    ),
+  },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    const now = Date.now();
+
+    const customRole = await ctx.db.get(args.customRoleId);
+    if (customRole === null || customRole.tenantId !== args.tenantId) {
+      throw new ConvexError({
+        code: "CUSTOM_ROLE_NOT_FOUND",
+        message: "Custom role does not exist in this tenant",
+        customRoleId: args.customRoleId,
+      });
+    }
+
+    const role = `custom:${args.customRoleId}`;
+    const scopeKey = args.scope
+      ? `${args.scope.type}:${args.scope.id}`
+      : "global";
+
+    const inputs: AssignmentInputs = {
+      tenantId: args.tenantId,
+      userId: args.userId,
+      role,
+      rolePermissions: customRole.permissions,
+      scope: args.scope,
+      scopeKey,
+      expiresAt: args.expiresAt,
+      assignedBy: args.assignedBy,
+      metadata: args.metadata,
+      policyClassifications: args.policyClassifications,
+      now,
+    };
+
+    const existingId = await tryExtendExistingAssignment(ctx, inputs);
+    if (existingId !== null) return existingId;
+
+    const assignmentId = await writeNewAssignment(ctx, inputs);
+
+    if (args.enableAudit) {
+      await ctx.db.insert("auditLog", {
+        tenantId: args.tenantId,
+        timestamp: now,
+        action: "role_assigned",
+        userId: args.userId,
+        actorId: args.assignedBy,
+        details: {
+          role,
+          scope: args.scope,
+          customRoleId: args.customRoleId,
+          customRoleName: customRole.name,
+        },
+      });
+    }
+
+    return assignmentId;
+  },
+});
+
+/**
+ * Unified Custom Role Revocation
+ *
+ * Revokes a custom role assignment from a user. Looks up the customRoles row
+ * to obtain the snapshot permission list (so we know which `effectivePermissions`
+ * rows to scrub), then delegates to the shared revoke helper.
+ *
+ * Returns false if there was no matching assignment (idempotent). Throws
+ * `CUSTOM_ROLE_NOT_FOUND` only when the role row itself is missing — not when
+ * the user simply doesn't hold it.
+ */
+export const revokeCustomRoleUnified = mutation({
+  args: {
+    tenantId: v.string(),
+    userId: v.string(),
+    customRoleId: v.id("customRoles"),
+    scope: scopeValidator,
+    revokedBy: v.optional(v.string()),
+    enableAudit: v.optional(v.boolean()),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const now = Date.now();
+
+    const customRole = await ctx.db.get(args.customRoleId);
+    if (customRole === null || customRole.tenantId !== args.tenantId) {
+      throw new ConvexError({
+        code: "CUSTOM_ROLE_NOT_FOUND",
+        message: "Custom role does not exist in this tenant",
+        customRoleId: args.customRoleId,
+      });
+    }
+
+    const role = `custom:${args.customRoleId}`;
+    const scopeKey = args.scope
+      ? `${args.scope.type}:${args.scope.id}`
+      : "global";
+
+    const revoked = await revokeAssignmentDualWrite(ctx, {
+      tenantId: args.tenantId,
+      userId: args.userId,
+      role,
+      rolePermissions: customRole.permissions,
+      scope: args.scope,
+      scopeKey,
+      now,
+    });
+
+    if (!revoked) return false;
+
+    if (args.enableAudit) {
+      await ctx.db.insert("auditLog", {
+        tenantId: args.tenantId,
+        timestamp: now,
+        action: "role_revoked",
+        userId: args.userId,
+        actorId: args.revokedBy,
+        details: {
+          role,
+          scope: args.scope,
+          customRoleId: args.customRoleId,
+          customRoleName: customRole.name,
+        },
+      });
+    }
+
     return true;
   },
 });
@@ -1583,83 +1776,23 @@ export const revokeRolesUnified = mutation({
     let revoked = 0;
 
     for (const item of args.roles) {
-      // 1. Compute scopeKey
       const scopeKey = item.scope
         ? `${item.scope.type}:${item.scope.id}`
         : "global";
 
-      // 2. Find the role assignment in roleAssignments
-      const assignments = await ctx.db
-        .query("roleAssignments")
-        .withIndex("by_tenant_user_and_role", (q) =>
-          q
-            .eq("tenantId", args.tenantId)
-            .eq("userId", args.userId)
-            .eq("role", item.role)
-        )
-        .take(100);
+      const wasRevoked = await revokeAssignmentDualWrite(ctx, {
+        tenantId: args.tenantId,
+        userId: args.userId,
+        role: item.role,
+        rolePermissions: args.rolePermissionsMap[item.role] ?? [],
+        scope: item.scope,
+        scopeKey,
+        now,
+      });
 
-      const assignment = assignments.find(
-        (row) => scopeEquals(row.scope, item.scope)
-      );
-
-      if (!assignment) {
-        continue;
-      }
-
-      // 3. Delete from roleAssignments
-      await ctx.db.delete(assignment._id);
+      if (!wasRevoked) continue;
       revoked++;
 
-      // 4. Delete from effectiveRoles
-      const effectiveRole = await ctx.db
-        .query("effectiveRoles")
-        .withIndex("by_tenant_user_role_scope", (q) =>
-          q
-            .eq("tenantId", args.tenantId)
-            .eq("userId", args.userId)
-            .eq("role", item.role)
-            .eq("scopeKey", scopeKey)
-        )
-        .unique();
-
-      if (effectiveRole) {
-        await ctx.db.delete(effectiveRole._id);
-      }
-
-      // 5. For each permission the role grants, update effectivePermissions
-      const permissions = args.rolePermissionsMap[item.role] ?? [];
-      for (const permission of permissions) {
-        const effectivePerm = await ctx.db
-          .query("effectivePermissions")
-          .withIndex("by_tenant_user_permission_scope", (q) =>
-            q
-              .eq("tenantId", args.tenantId)
-              .eq("userId", args.userId)
-              .eq("permission", permission)
-              .eq("scopeKey", scopeKey)
-          )
-          .unique();
-
-        if (!effectivePerm) continue;
-
-        const updatedSources = effectivePerm.sources.filter(
-          (s) => s !== item.role
-        );
-
-        if (updatedSources.length === 0 && !effectivePerm.directGrant && !effectivePerm.directDeny) {
-          // No more sources, no direct grant, no direct deny — delete the row
-          await ctx.db.delete(effectivePerm._id);
-        } else if (updatedSources.length !== effectivePerm.sources.length) {
-          // Role was in sources; patch with updated array
-          await ctx.db.patch(effectivePerm._id, {
-            sources: updatedSources,
-            updatedAt: now,
-          });
-        }
-      }
-
-      // 6. Audit log if enableAudit
       if (args.enableAudit) {
         await ctx.db.insert("auditLog", {
           tenantId: args.tenantId,


### PR DESCRIPTION
## Summary

Adds opt-in support for **tenant-admin-defined custom roles** so B2B SaaS customers can model their own org charts at runtime. Resolves #31.

The design preserves all three existing properties:
1. **Compile-time type safety** for static roles (the #23 win — `authz.can("documets:read")` is still a TS error)
2. **O(1) hot-path reads** — `can()` and `hasRole()` paths are unchanged; custom roles are invisible to the read path
3. **No permission-escalation surface** — tenants compose, never invent

## Design (TL;DR)

**Dual catalog.** System roles (`defineRoles(...)`) stay typed as today. Custom roles are tenant-scoped DB rows identified by branded `Id<"customRoles">`, composed only from a SaaS-provider-defined `grantablePermissions` whitelist that is itself typed as `ReadonlyArray<PermissionArg<P>>` (so typos in the whitelist fail to compile).

```ts
const authz = new Authz(components.authz, {
  permissions, roles, tenantId,
  customRoles: {
    enabled: true,
    grantablePermissions: ["docs:read", "docs:write"] as const,
    maxRolesPerTenant: 50,
  },
});

const roleId = await authz.createCustomRole(ctx, { name, permissions, createdBy });
await authz.assignCustomRole(ctx, userId, roleId);
const allowed = await authz.can(ctx, userId, "docs:write"); // unchanged signature
```

**Storage:** custom-role assignments use the namespaced string `"custom:<id>"` in `roleAssignments.role`/`effectiveRoles.role`, so the existing read indexes (`by_tenant_user_permission_scope`, `by_tenant_user_role_scope`) work unchanged.

**Cascade-on-update:** when a tenant admin edits a role, all assigned users are recomputed via `recomputeUser` (mirrors `syncRoleAction`). No-op edits skip the fan-out.

**Snapshot semantics:** custom-role permissions are a snapshot at create time; updating a *system* role definition does not auto-update custom roles built on it (prevents redeploy-breaks-tenant footgun).

## What's new

| Layer | Files |
|---|---|
| Schema | `customRoles` table + 3 audit action types in `schema.ts` |
| Backend | `src/component/customRoles.ts` (new); 4 new mutations + 1 action + helpers in `src/component/unified.ts` |
| Client | 8 new methods on `Authz`, `CustomRolesConfig<P>`, branded `CustomRoleId`, 4 new validators |
| Tests | 64 new tests across 5 files (CRUD, assign, cascade, type-safety, end-to-end scenarios incl. cross-tenant) |
| Docs | README section, CLAUDE.md updates, `example/convex/customRolesExample.ts` |
| Demo UI | New "Custom Roles" page in the example app exercising the full lifecycle |

**Net diff:** +4,054 / -470 across 17 files. Includes a refactor that extracts shared dual-write helpers (-65 lines while gaining the feature).

## Performance

Zero hot-path regression — proven by tracing, not asserted:

| Path | Impact |
|---|---|
| `can()` / `checkPermissionFast` | **Zero.** Touches only `effectivePermissions`; permission origin is invisible. |
| `hasRole()` / `hasRoleFast` | **Zero.** Same index, same row count. |
| `assignCustomRole()` | **+1 read** to fetch the snapshot permission list — same shape as `assignRoleUnified`. |
| `updateCustomRole()` cascade | **Cold path.** Same cost model as existing `syncRoleAction`. |

Users who don't enable `customRoles` pay literally zero.

## Browser-verified end-to-end

The PR was driven through Playwright on the example app. Verified flows:
- Create role with whitelisted perms → persisted, listed
- Assign to user → `can()` returns true for granted perms
- Toggle a new perm + Apply → "1 user(s) recomputed", `can()` flips false → true (cascade verified)
- Apply with same set → "No-op (set unchanged)" (set-equality detection)
- Force-delete role with active assignment → user permissions revoked
- Backend rejection of non-whitelisted `documents:delete` → throws "not in customRoles.grantablePermissions"

A Playwright run also caught a real bug: `ctx.db.paginate()` is not supported inside Convex components (same root cause as #41). Fixed in `488dabd` by switching to `convex-helpers`' `paginator(ctx.db, schema)`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — **733/733 passing** (was 669 before this branch)
- [x] `npm run build` clean
- [x] Type-safety tests with `--typecheck`: all `@ts-expect-error` directives fire
- [x] Cross-tenant isolation: custom role in tenant A invisible/unassignable from tenant B (8 scenarios)
- [x] Browser-tested in the example app via Playwright
- [x] No regressions in pre-existing 669 tests

## Merge guidance

Use **merge commit** (not squash) so all 12 conventional commits flow through to release-please for a properly grouped CHANGELOG. Merging this PR will trigger release-please to open a `chore: release 2.4.0` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)