### PR TITLE
feat: removeOverride API + example UI + extended tests (combines #43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,9 @@ await authz.grantPermission(ctx, userId, "documents:*", undefined, "Full documen
 
 // Deny read on any resource
 await authz.denyPermission(ctx, userId, "*:read", undefined, "Read access revoked");
+
+// Remove the direct override and fall back to role/policy-derived access
+await authz.removeOverride(ctx, userId, "*:read");
 ```
 
 **Role definitions:** When the component evaluates permissions, it matches the requested permission against each role’s permission list using the same pattern rules. So if a role’s permissions include `"documents:*"` (in the flattened role–permission map), then `can(ctx, userId, "documents:read")` is allowed. With `defineRoles` you typically list concrete actions per resource (e.g. `documents: ["read", "update"]`); to use patterns in roles you would supply a role-permission map that includes pattern strings for that role.
@@ -1029,6 +1032,16 @@ await authz.grantPermission(ctx, userId, "documents:delete", undefined, "Tempora
 await authz.denyPermission(ctx, userId, "documents:delete", undefined, "Access restricted");
 ```
 
+### Removing Permission Overrides
+
+```typescript
+// Remove a direct grant or deny and restore access from roles/policies
+await authz.removeOverride(ctx, userId, "documents:delete");
+
+// With scope
+await authz.removeOverride(ctx, userId, "documents:delete", { type: "team", id: "team_123" });
+```
+
 ---
 
 ## Schema Reference
@@ -1100,6 +1113,7 @@ class Authz<P, R, Policy> {
   // Permission overrides
   grantPermission(ctx, userId, permission, scope?, reason?, expiresAt?, actorId?): Promise<string>
   denyPermission(ctx, userId, permission, scope?, reason?, expiresAt?, actorId?): Promise<string>
+  removeOverride(ctx, userId, permission, scope?, actorId?): Promise<boolean>
   
   // Audit
   getAuditLog(ctx, options?): Promise<AuditEntry[] | { page: AuditEntry[]; isDone: boolean; continueCursor: string }>

--- a/README.md
+++ b/README.md
@@ -1034,11 +1034,25 @@ await authz.denyPermission(ctx, userId, "documents:delete", undefined, "Access r
 
 ### Removing Permission Overrides
 
-```typescript
-// Remove a direct grant or deny and restore access from roles/policies
-await authz.removeOverride(ctx, userId, "documents:delete");
+`grantPermission` and `denyPermission` are **not** inverses. They upsert into
+the same `permissionOverrides` row (keyed by user + permission + scope), so
+calling `denyPermission` after `grantPermission` rewrites the row's `effect`
+from `"allow"` to `"deny"` — the override persists, just inverted. A deny is
+meaningfully different from "no override at all": a deny blocks the
+permission even if the user holds it via a role, while no override lets
+role-derived access flow through normally.
 
-// With scope
+To truly undo an override and return to baseline (no row in
+`permissionOverrides`), use `removeOverride`. After removal, role-derived
+sources, deferred policy state, and role-based expiry are all properly
+restored on the effective row.
+
+```typescript
+// Remove a direct grant or deny — returns true if a row was deleted, false if no
+// override existed for the given (user, permission, scope) tuple. Idempotent.
+const removed = await authz.removeOverride(ctx, userId, "documents:delete");
+
+// Scope must match the original override exactly — global is distinct from scoped
 await authz.removeOverride(ctx, userId, "documents:delete", { type: "team", id: "team_123" });
 ```
 

--- a/example/convex/app.ts
+++ b/example/convex/app.ts
@@ -393,6 +393,30 @@ export const denyPermission = mutation({
   },
 });
 
+/**
+ * Remove a permission override (grant or deny) for a user. The third symmetric
+ * counterpart to grantPermission / denyPermission — see Authz.removeOverride.
+ */
+export const removeOverride = mutation({
+  args: {
+    userId: v.id("users"),
+    permission: v.string(),
+    orgId: v.optional(v.id("orgs")),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const scope = args.orgId
+      ? { type: "org", id: String(args.orgId) }
+      : undefined;
+    return await authz.removeOverride(
+      ctx,
+      String(args.userId),
+      args.permission as any,
+      scope,
+    );
+  },
+});
+
 // ============================================================================
 // Custom Roles (issue #31) — tenant admins compose roles at runtime
 // ============================================================================

--- a/example/src/pages/permission-tester.tsx
+++ b/example/src/pages/permission-tester.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useQuery } from "convex/react";
+import { useQuery, useMutation } from "convex/react";
 import { api } from "@convex/_generated/api";
 import { useCanUser, PermissionGate } from "@djpanda/convex-authz/react";
 import {
@@ -11,7 +11,16 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { CheckCircle2, XCircle, Shield, User, Building2 } from "lucide-react";
+import {
+  CheckCircle2,
+  XCircle,
+  Shield,
+  User,
+  Building2,
+  Plus,
+  Ban,
+  Eraser,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Id } from "@convex/_generated/dataModel";
 
@@ -311,6 +320,14 @@ export function PermissionTesterPage() {
         </Card>
       )}
 
+      {/* Overrides panel — exercises grant / deny / removeOverride */}
+      {selectedUserId && (
+        <OverridesPanel
+          userId={selectedUserId}
+          orgId={selectedOrgId}
+        />
+      )}
+
       {/* Empty State */}
       {!selectedUserId && (
         <Card className="border-dashed">
@@ -322,5 +339,115 @@ export function PermissionTesterPage() {
         </Card>
       )}
     </div>
+  );
+}
+
+interface OverridesPanelProps {
+  userId: Id<"users">;
+  orgId: Id<"orgs"> | null;
+}
+
+/**
+ * Demonstrates the override lifecycle: grant a permission directly, deny one
+ * even if the user has it via role, and remove either kind of override. This
+ * showcases the symmetric `removeOverride` API. The grid above this panel
+ * uses Convex's reactive queries, so each click visibly flips the relevant
+ * permission's allow/deny state in real time.
+ */
+function OverridesPanel({ userId, orgId }: OverridesPanelProps) {
+  const [permission, setPermission] = useState<string>("documents:delete");
+  const [lastAction, setLastAction] = useState<string | null>(null);
+
+  const grant = useMutation(api.app.grantPermission);
+  const deny = useMutation(api.app.denyPermission);
+  const remove = useMutation(api.app.removeOverride);
+
+  const orgArg = orgId ?? undefined;
+
+  const handleGrant = async () => {
+    await grant({ userId, permission, orgId: orgArg });
+    setLastAction(`Granted ${permission}`);
+  };
+  const handleDeny = async () => {
+    await deny({ userId, permission, orgId: orgArg });
+    setLastAction(`Denied ${permission}`);
+  };
+  const handleRemove = async () => {
+    const removed = await remove({ userId, permission, orgId: orgArg });
+    setLastAction(
+      removed
+        ? `Override removed for ${permission}`
+        : `No override existed for ${permission}`,
+    );
+  };
+
+  return (
+    <Card data-testid="overrides-panel">
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          <Eraser className="size-4" />
+          Permission Overrides
+        </CardTitle>
+        <CardDescription>
+          Pick a permission, then try{" "}
+          <code className="text-xs">grantPermission</code>,{" "}
+          <code className="text-xs">denyPermission</code>, and{" "}
+          <code className="text-xs">removeOverride</code>. Watch the row
+          above react in real time.{" "}
+          <strong>
+            grant and deny are NOT inverses — they upsert the same row's
+            effect; removeOverride is the only way to delete the row and
+            restore role-derived access.
+          </strong>
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div>
+          <label className="text-xs text-muted-foreground mb-2 block">
+            Permission
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {PERMISSIONS.map((p) => (
+              <Button
+                key={p}
+                size="sm"
+                variant={permission === p ? "default" : "outline"}
+                onClick={() => {
+                  setPermission(p);
+                  setLastAction(null);
+                }}
+                data-testid={`override-perm-${p}`}
+              >
+                {p}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button onClick={handleGrant} data-testid="override-grant">
+            <Plus className="size-4 mr-2" />
+            Grant
+          </Button>
+          <Button onClick={handleDeny} variant="secondary" data-testid="override-deny">
+            <Ban className="size-4 mr-2" />
+            Deny
+          </Button>
+          <Button onClick={handleRemove} variant="outline" data-testid="override-remove">
+            <Eraser className="size-4 mr-2" />
+            Remove override
+          </Button>
+        </div>
+
+        {lastAction && (
+          <div
+            className="text-sm text-muted-foreground"
+            data-testid="override-last-action"
+          >
+            Last action: {lastAction}
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/skills/convex-authz/SKILL.md
+++ b/skills/convex-authz/SKILL.md
@@ -520,6 +520,9 @@ await authz.grantPermission(ctx, userId, "documents:*", undefined, "Full documen
 
 // Deny read on any resource
 await authz.denyPermission(ctx, userId, "*:read", undefined, "Read access revoked");
+
+// Remove the direct override and fall back to role/policy-derived access
+await authz.removeOverride(ctx, userId, "*:read");
 ```
 
 **Role definitions:** When the component evaluates permissions, it matches the requested permission against each role’s permission list using the same pattern rules. So if a role’s permissions include `"documents:*"` (in the flattened role–permission map), then `can(ctx, userId, "documents:read")` is allowed. With `defineRoles` you typically list concrete actions per resource (e.g. `documents: ["read", "update"]`); to use patterns in roles you would supply a role-permission map that includes pattern strings for that role.
@@ -1053,6 +1056,30 @@ await authz.grantPermission(ctx, userId, "documents:delete", undefined, "Tempora
 await authz.denyPermission(ctx, userId, "documents:delete", undefined, "Access restricted");
 ```
 
+### Removing Permission Overrides
+
+`grantPermission` and `denyPermission` are **not** inverses. They upsert into
+the same `permissionOverrides` row (keyed by user + permission + scope), so
+calling `denyPermission` after `grantPermission` rewrites the row's `effect`
+from `"allow"` to `"deny"` — the override persists, just inverted. A deny is
+meaningfully different from "no override at all": a deny blocks the
+permission even if the user holds it via a role, while no override lets
+role-derived access flow through normally.
+
+To truly undo an override and return to baseline (no row in
+`permissionOverrides`), use `removeOverride`. After removal, role-derived
+sources, deferred policy state, and role-based expiry are all properly
+restored on the effective row.
+
+```typescript
+// Remove a direct grant or deny — returns true if a row was deleted, false if no
+// override existed for the given (user, permission, scope) tuple. Idempotent.
+const removed = await authz.removeOverride(ctx, userId, "documents:delete");
+
+// Scope must match the original override exactly — global is distinct from scoped
+await authz.removeOverride(ctx, userId, "documents:delete", { type: "team", id: "team_123" });
+```
+
 ---
 
 ## Schema Reference
@@ -1124,6 +1151,7 @@ class Authz<P, R, Policy> {
   // Permission overrides
   grantPermission(ctx, userId, permission, scope?, reason?, expiresAt?, actorId?): Promise<string>
   denyPermission(ctx, userId, permission, scope?, reason?, expiresAt?, actorId?): Promise<string>
+  removeOverride(ctx, userId, permission, scope?, actorId?): Promise<boolean>
   
   // Audit
   getAuditLog(ctx, options?): Promise<AuditEntry[] | { page: AuditEntry[]; isDone: boolean; continueCursor: string }>

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -577,6 +577,7 @@ describe("Authz class", () => {
         revokeAllRolesUnified: "unified.revokeAllRolesUnified",
         grantPermissionUnified: "unified.grantPermissionUnified",
         denyPermissionUnified: "unified.denyPermissionUnified",
+        removeOverrideUnified: "unified.removeOverrideUnified",
         addRelationUnified: "unified.addRelationUnified",
         removeRelationUnified: "unified.removeRelationUnified",
         recomputeUser: "unified.recomputeUser",
@@ -1671,6 +1672,62 @@ describe("Authz class", () => {
           objectId: "sales",
           tenantId: "test-tenant",
         }
+      );
+    });
+  });
+
+  describe("removeOverride", () => {
+    it("should remove permission override via unified.removeOverrideUnified", async () => {
+      const component = createMockComponent();
+      const authz = new Authz(component, { permissions, roles, tenantId: "test-tenant" });
+
+      const ctx = {
+        runMutation: vi.fn().mockResolvedValue(true),
+      };
+
+      const result = await authz.removeOverride(
+        ctx,
+        "user_123",
+        "documents:delete"
+      );
+
+      expect(result).toBe(true);
+      expect(ctx.runMutation).toHaveBeenCalledWith(
+        component.unified.removeOverrideUnified,
+        expect.objectContaining({
+          userId: "user_123",
+          permission: "documents:delete",
+          enableAudit: true,
+          tenantId: "test-tenant",
+        })
+      );
+    });
+
+    it("should pass scope and actorId", async () => {
+      const component = createMockComponent();
+      const authz = new Authz(component, { permissions, roles, tenantId: "test-tenant" });
+
+      const ctx = {
+        runMutation: vi.fn().mockResolvedValue(true),
+      };
+
+      const scope = { type: "doc", id: "doc_1" };
+      await authz.removeOverride(
+        ctx,
+        "user_123",
+        "documents:delete",
+        scope,
+        "actor_1"
+      );
+
+      expect(ctx.runMutation).toHaveBeenCalledWith(
+        component.unified.removeOverrideUnified,
+        expect.objectContaining({
+          scope,
+          removedBy: "actor_1",
+          tenantId: "test-tenant",
+          rolePermissionsMap: expect.any(Object),
+        })
       );
     });
   });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1367,6 +1367,32 @@ export class Authz<
   }
 
   /**
+   * Remove a direct permission override and restore role/policy-derived access.
+   * Returns false when no matching override exists.
+   */
+  async removeOverride(
+    ctx: MutationCtx | ActionCtx,
+    userId: string,
+    permission: PermissionArg<P>,
+    scope?: Scope,
+    actorId?: string
+  ): Promise<boolean> {
+    validateUserId(userId);
+    validatePermission(permission);
+    validateScope(scope);
+    return await ctx.runMutation(this.component.unified.removeOverrideUnified, {
+      tenantId: this.options.tenantId,
+      userId,
+      permission,
+      scope,
+      rolePermissionsMap: this.buildRolePermissionsMap(),
+      policyClassifications: this.buildPolicyClassifications(),
+      removedBy: actorId ?? this.options.defaultActorId,
+      enableAudit: true,
+    });
+  }
+
+  /**
    * Check relationship - O(1) indexed lookup
    */
   async hasRelation(
@@ -1595,6 +1621,7 @@ export class Authz<
         | "role_revoked"
         | "permission_granted"
         | "permission_denied"
+        | "permission_override_removed"
         | "attribute_set"
         | "attribute_removed"
         | "relation_added"

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -365,6 +365,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             | "role_revoked"
             | "permission_granted"
             | "permission_denied"
+            | "permission_override_removed"
             | "attribute_set"
             | "attribute_removed"
             | "relation_added"
@@ -728,6 +729,25 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           userId: string;
         },
         null,
+        Name
+      >;
+      removeOverrideUnified: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          enableAudit?: boolean;
+          permission: string;
+          policyClassifications?: Record<
+            string,
+            null | "allow" | "deny" | "deferred"
+          >;
+          removedBy?: string;
+          rolePermissionsMap: Record<string, Array<string>>;
+          scope?: { id: string; type: string };
+          tenantId: string;
+          userId: string;
+        },
+        boolean,
         Name
       >;
       removeRelationUnified: FunctionReference<

--- a/src/component/queries.ts
+++ b/src/component/queries.ts
@@ -246,6 +246,7 @@ const auditLogActionValidator = v.union(
   v.literal("role_revoked"),
   v.literal("permission_granted"),
   v.literal("permission_denied"),
+  v.literal("permission_override_removed"),
   v.literal("attribute_set"),
   v.literal("attribute_removed"),
   v.literal("relation_added"),
@@ -326,6 +327,7 @@ export const getAuditLog = query({
                 | "role_revoked"
                 | "permission_granted"
                 | "permission_denied"
+                | "permission_override_removed"
                 | "attribute_set"
                 | "attribute_removed"
                 | "relation_added"

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -176,6 +176,7 @@ export default defineSchema({
       v.literal("role_revoked"),
       v.literal("permission_granted"),
       v.literal("permission_denied"),
+      v.literal("permission_override_removed"),
       v.literal("attribute_set"),
       v.literal("attribute_removed"),
       v.literal("relation_added"),

--- a/src/component/tests/mutations.test.ts
+++ b/src/component/tests/mutations.test.ts
@@ -1046,6 +1046,235 @@ describe("mutations - additional coverage", () => {
     });
   });
 
+  describe("removeOverride", () => {
+    it("should remove a direct override and delete effective permission with no remaining sources", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.unified.grantPermissionUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        reason: "Temporary access",
+      });
+
+      const result = await t.mutation(api.unified.removeOverrideUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        rolePermissionsMap: {},
+        removedBy: "actor_1",
+        enableAudit: true,
+      });
+
+      expect(result).toBe(true);
+
+      const overrides = await t.query(api.queries.getPermissionOverrides, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+      expect(overrides).toHaveLength(0);
+
+      const check = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+      expect(check.allowed).toBe(false);
+
+      const logsResult = await t.query(api.queries.getAuditLog, {
+        tenantId: TENANT,
+        userId: "user_123",
+      });
+      const logs = Array.isArray(logsResult) ? logsResult : logsResult.page;
+      expect(logs.some((l) => l.action === "permission_override_removed")).toBe(true);
+    });
+
+    it("should restore role-derived allow after removing a deny override", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.unified.assignRoleUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        role: "editor",
+        rolePermissions: ["documents:delete"],
+      });
+
+      await t.mutation(api.unified.denyPermissionUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        reason: "Temporary block",
+      });
+
+      let check = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+      expect(check.allowed).toBe(false);
+
+      const result = await t.mutation(api.unified.removeOverrideUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        rolePermissionsMap: {
+          editor: ["documents:delete"],
+        },
+      });
+
+      expect(result).toBe(true);
+
+      check = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+      expect(check.allowed).toBe(true);
+
+      const effectivePerms = await t.run(async (ctx) =>
+        await ctx.db.query("effectivePermissions").collect()
+      );
+      const restored = effectivePerms.find(
+        (perm) =>
+          perm.userId === "user_123" &&
+          perm.permission === "documents:delete" &&
+          perm.scopeKey === "global"
+      );
+
+      expect(restored).toBeDefined();
+      expect(restored?.effect).toBe("allow");
+      expect(restored?.sources).toEqual(["editor"]);
+      expect(restored?.directDeny).toBeUndefined();
+      expect(restored?.directGrant).toBeUndefined();
+      expect(restored?.reason).toBeUndefined();
+    });
+
+    it("should restore role expiration after removing a grant override", async () => {
+      const t = convexTest(schema, modules);
+      const expiresAt = Date.now() + 3600000;
+
+      await t.mutation(api.unified.assignRoleUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        role: "editor",
+        rolePermissions: ["documents:delete"],
+        expiresAt,
+      });
+
+      await t.mutation(api.unified.grantPermissionUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+
+      await t.mutation(api.unified.removeOverrideUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        rolePermissionsMap: {
+          editor: ["documents:delete"],
+        },
+      });
+
+      const effectivePerms = await t.run(async (ctx) =>
+        await ctx.db.query("effectivePermissions").collect()
+      );
+      const restored = effectivePerms.find(
+        (perm) => perm.userId === "user_123" && perm.permission === "documents:delete"
+      );
+
+      expect(restored?.expiresAt).toBe(expiresAt);
+    });
+
+    it("should restore deferred policy state after removing a grant override", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.unified.assignRoleUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        role: "editor",
+        rolePermissions: ["documents:delete"],
+        policyClassifications: {
+          "documents:delete": "deferred",
+        },
+      });
+
+      await t.mutation(api.unified.grantPermissionUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+
+      await t.mutation(api.unified.removeOverrideUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        rolePermissionsMap: {
+          editor: ["documents:delete"],
+        },
+        policyClassifications: {
+          "documents:delete": "deferred",
+        },
+      });
+
+      const check = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+
+      expect(check.allowed).toBe(true);
+      expect(check.tier).toBe("deferred");
+      expect(check.policyName).toBe("documents:delete");
+    });
+
+    it("should drop stale role sources that are no longer in the role permissions map", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.mutation(api.unified.assignRoleUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        role: "legacy_editor",
+        rolePermissions: ["documents:delete"],
+      });
+
+      await t.mutation(api.unified.denyPermissionUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+
+      await t.mutation(api.unified.removeOverrideUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        rolePermissionsMap: {},
+      });
+
+      const check = await t.query(api.unified.checkPermission, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+      });
+
+      expect(check.allowed).toBe(false);
+    });
+
+    it("should return false when no matching override exists", async () => {
+      const t = convexTest(schema, modules);
+
+      const result = await t.mutation(api.unified.removeOverrideUnified, {
+        tenantId: TENANT,
+        userId: "user_123",
+        permission: "documents:delete",
+        rolePermissionsMap: {},
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
 
 
   describe("cleanupExpired", () => {

--- a/src/component/tests/removeOverride.additional.test.ts
+++ b/src/component/tests/removeOverride.additional.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Additional removeOverrideUnified test categories that complement the core
+ * correctness tests in mutations.test.ts (added in PR #43): cross-tenant
+ * isolation, scope discrimination, wildcard overrides, audit log fidelity,
+ * and composability with the v2.4 customRoles feature.
+ */
+
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import schema from "../schema.js";
+import { api } from "../_generated/api.js";
+
+const modules = import.meta.glob("../**/*.ts");
+
+const TENANT_A = "tenant-acme";
+const TENANT_B = "tenant-globex";
+const USER = "user-1";
+
+// Empty maps are accepted by removeOverrideUnified — the mutation only walks
+// roleAssignments.role keys present in the map. Tests that need role-based
+// preservation pass an explicit map.
+const EMPTY_ROLE_MAP = {};
+
+describe("removeOverrideUnified: cross-tenant isolation", () => {
+  it("override in tenant A is not removable from tenant B", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.unified.grantPermissionUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+    });
+
+    // Removal call from TENANT_B should be a no-op (override is invisible)
+    const fromB = await t.mutation(api.unified.removeOverrideUnified, {
+      tenantId: TENANT_B,
+      userId: USER,
+      permission: "docs:read",
+      rolePermissionsMap: EMPTY_ROLE_MAP,
+    });
+    expect(fromB).toBe(false);
+
+    // Tenant A still sees the override
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: USER,
+          permission: "docs:read",
+        })
+      ).allowed,
+    ).toBe(true);
+  });
+});
+
+describe("removeOverrideUnified: scope discrimination", () => {
+  it("global override is distinct from a scoped override at the same permission", async () => {
+    const t = convexTest(schema, modules);
+
+    // Global grant
+    await t.mutation(api.unified.grantPermissionUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+    });
+    // Scoped grant on team-7
+    await t.mutation(api.unified.grantPermissionUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+      scope: { type: "team", id: "team-7" },
+    });
+
+    // Remove only the scoped one
+    const removed = await t.mutation(api.unified.removeOverrideUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+      scope: { type: "team", id: "team-7" },
+      rolePermissionsMap: EMPTY_ROLE_MAP,
+    });
+    expect(removed).toBe(true);
+
+    // Global still present
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: USER,
+          permission: "docs:read",
+        })
+      ).allowed,
+    ).toBe(true);
+  });
+
+  it("attempting to remove a scoped override with a global call is a no-op", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.unified.grantPermissionUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+      scope: { type: "team", id: "team-7" },
+    });
+
+    // No scope passed — should not match the scoped override
+    const removed = await t.mutation(api.unified.removeOverrideUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+      rolePermissionsMap: EMPTY_ROLE_MAP,
+    });
+    expect(removed).toBe(false);
+
+    // Scoped override still in effect
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: USER,
+          permission: "docs:read",
+          scope: { type: "team", id: "team-7" },
+        })
+      ).allowed,
+    ).toBe(true);
+  });
+});
+
+describe("removeOverrideUnified: wildcard overrides", () => {
+  it("removes a wildcard grant (e.g. docs:*) and clears matched permissions", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.unified.grantPermissionUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:*",
+    });
+
+    // Wildcard match: docs:read should be allowed
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: USER,
+          permission: "docs:read",
+        })
+      ).allowed,
+    ).toBe(true);
+
+    // Remove the wildcard override
+    const removed = await t.mutation(api.unified.removeOverrideUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:*",
+      rolePermissionsMap: EMPTY_ROLE_MAP,
+    });
+    expect(removed).toBe(true);
+
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: USER,
+          permission: "docs:read",
+        })
+      ).allowed,
+    ).toBe(false);
+  });
+});
+
+describe("removeOverrideUnified: audit log fidelity", () => {
+  it("writes a permission_override_removed entry when enableAudit is true", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.unified.grantPermissionUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+    });
+
+    await t.mutation(api.unified.removeOverrideUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+      rolePermissionsMap: EMPTY_ROLE_MAP,
+      removedBy: "admin-1",
+      enableAudit: true,
+    });
+
+    const logsResult = await t.query(api.queries.getAuditLog, {
+      tenantId: TENANT_A,
+      action: "permission_override_removed",
+    });
+    const logs = Array.isArray(logsResult) ? logsResult : logsResult.page;
+    expect(logs).toHaveLength(1);
+    expect(logs[0].userId).toBe(USER);
+    expect(logs[0].actorId).toBe("admin-1");
+    const details = logs[0].details as { permission?: string; reason?: string };
+    expect(details.permission).toBe("docs:read");
+    expect(details.reason).toContain("allow"); // previous effect
+  });
+
+  it("audit reason reflects whether the removed override was a grant or a deny", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.unified.denyPermissionUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+    });
+
+    await t.mutation(api.unified.removeOverrideUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+      rolePermissionsMap: EMPTY_ROLE_MAP,
+      enableAudit: true,
+    });
+
+    const logsResult = await t.query(api.queries.getAuditLog, {
+      tenantId: TENANT_A,
+      action: "permission_override_removed",
+    });
+    const logs = Array.isArray(logsResult) ? logsResult : logsResult.page;
+    const details = logs[0].details as { reason?: string };
+    expect(details.reason).toContain("deny");
+  });
+
+  it("does not write an audit entry when enableAudit is false/omitted", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(api.unified.grantPermissionUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+    });
+
+    await t.mutation(api.unified.removeOverrideUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+      rolePermissionsMap: EMPTY_ROLE_MAP,
+    });
+
+    const logsResult = await t.query(api.queries.getAuditLog, {
+      tenantId: TENANT_A,
+      action: "permission_override_removed",
+    });
+    const logs = Array.isArray(logsResult) ? logsResult : logsResult.page;
+    expect(logs).toHaveLength(0);
+  });
+});
+
+describe("removeOverrideUnified: composability with custom roles (v2.4)", () => {
+  it("removing a deny override leaves a user's custom-role-derived access intact", async () => {
+    const t = convexTest(schema, modules);
+
+    const roleId = await t.mutation(api.customRoles.createCustomRole, {
+      tenantId: TENANT_A,
+      name: "Editor",
+      permissions: ["docs:read"],
+      createdBy: "admin",
+      grantablePermissions: ["docs:read", "docs:write"],
+    });
+    await t.mutation(api.unified.assignCustomRoleUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      customRoleId: roleId,
+    });
+
+    // Layer a deny override on top of the custom-role-derived allow
+    await t.mutation(api.unified.denyPermissionUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+    });
+
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: USER,
+          permission: "docs:read",
+        })
+      ).allowed,
+    ).toBe(false);
+
+    // Remove the deny — custom-role-derived access comes back. Since custom
+    // roles are stored as "custom:<id>" in roleAssignments.role, the recompute
+    // path needs to know about them. The mutation falls back to the
+    // customRoles table for "custom:" prefixes (via recomputeUser semantics);
+    // here we pass an empty rolePermissionsMap because the only role the user
+    // holds is a custom one, and removeOverride rebuilds sources by scanning
+    // roleAssignments directly.
+    const customRoleString = `custom:${roleId}`;
+    await t.mutation(api.unified.removeOverrideUnified, {
+      tenantId: TENANT_A,
+      userId: USER,
+      permission: "docs:read",
+      rolePermissionsMap: { [customRoleString]: ["docs:read"] },
+    });
+
+    expect(
+      (
+        await t.query(api.unified.checkPermission, {
+          tenantId: TENANT_A,
+          userId: USER,
+          permission: "docs:read",
+        })
+      ).allowed,
+    ).toBe(true);
+  });
+});

--- a/src/component/unified.ts
+++ b/src/component/unified.ts
@@ -860,7 +860,7 @@ export const grantPermissionUnified = mutation({
           .eq("userId", args.userId)
           .eq("permission", args.permission)
       )
-      .take(100);
+      .take(4000);
 
     const existingOverride = existingOverrides.find((row) =>
       scopeEquals(row.scope, args.scope)
@@ -954,6 +954,177 @@ export const grantPermissionUnified = mutation({
 
     // 5. Return override ID
     return overrideId;
+  },
+});
+
+/**
+ * Remove a direct permission override.
+ *
+ * This deletes the source-of-truth override and clears directGrant/directDeny
+ * from the indexed effective permission. If the permission still has role or
+ * policy sources, the indexed row is restored to an allow from those sources;
+ * otherwise it is removed entirely.
+ */
+export const removeOverrideUnified = mutation({
+  args: {
+    tenantId: v.string(),
+    userId: v.string(),
+    permission: v.string(),
+    scope: scopeValidator,
+    rolePermissionsMap: v.record(v.string(), v.array(v.string())),
+    policyClassifications: v.optional(v.record(v.string(), v.union(
+      v.null(),
+      v.literal("allow"),
+      v.literal("deny"),
+      v.literal("deferred"),
+    ))),
+    removedBy: v.optional(v.string()),
+    enableAudit: v.optional(v.boolean()),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const scopeKey = args.scope
+      ? `${args.scope.type}:${args.scope.id}`
+      : "global";
+
+    const existingOverrides = await ctx.db
+      .query("permissionOverrides")
+      .withIndex("by_tenant_user_and_permission", (q) =>
+        q
+          .eq("tenantId", args.tenantId)
+          .eq("userId", args.userId)
+          .eq("permission", args.permission)
+      )
+      .take(100);
+
+    const existingOverride = existingOverrides.find((row) =>
+      scopeEquals(row.scope, args.scope)
+    );
+
+    if (!existingOverride) {
+      return false;
+    }
+
+    await ctx.db.delete(existingOverride._id);
+
+    const existingPerm = await ctx.db
+      .query("effectivePermissions")
+      .withIndex("by_tenant_user_permission_scope", (q) =>
+        q
+          .eq("tenantId", args.tenantId)
+          .eq("userId", args.userId)
+          .eq("permission", args.permission)
+          .eq("scopeKey", scopeKey)
+      )
+      .unique();
+
+    const roleAssignments = await ctx.db
+      .query("roleAssignments")
+      .withIndex("by_tenant_user", (q) =>
+        q.eq("tenantId", args.tenantId).eq("userId", args.userId)
+      )
+      .take(4000);
+
+    const nonRoleSources = existingPerm?.sources.filter((source) =>
+      source.startsWith("relation:")
+    ) ?? [];
+    const roleSources: string[] = [];
+    let roleExpiresAt: number | undefined | null = null;
+
+    for (const assignment of roleAssignments) {
+      if (!scopeEquals(assignment.scope, args.scope) || isExpired(assignment.expiresAt)) {
+        continue;
+      }
+
+      const permissions = args.rolePermissionsMap[assignment.role] ?? [];
+      const classification = args.policyClassifications?.[args.permission] ?? null;
+
+      if (!permissions.includes(args.permission) || classification === "deny") {
+        continue;
+      }
+
+      if (!roleSources.includes(assignment.role)) {
+        roleSources.push(assignment.role);
+      }
+
+      if (assignment.expiresAt === undefined) {
+        roleExpiresAt = undefined;
+      } else if (roleExpiresAt !== undefined) {
+        roleExpiresAt =
+          roleExpiresAt === null
+            ? assignment.expiresAt
+            : Math.max(roleExpiresAt, assignment.expiresAt);
+      }
+    }
+
+    const sources = [...nonRoleSources, ...roleSources];
+
+    if (sources.length > 0) {
+      const classification = args.policyClassifications?.[args.permission] ?? null;
+      const patchData: Record<string, unknown> = {
+        directGrant: undefined,
+        directDeny: undefined,
+        effect: "allow",
+        sources,
+        reason: undefined,
+        expiresAt: nonRoleSources.length > 0
+          ? existingPerm?.expiresAt
+          : roleExpiresAt === null
+            ? undefined
+            : roleExpiresAt,
+        policyResult: undefined,
+        policyName: undefined,
+        updatedAt: now,
+      };
+
+      if (classification === "deferred") {
+        patchData.policyResult = "deferred";
+        patchData.policyName = args.permission;
+      } else if (classification === "allow") {
+        patchData.policyResult = "allow";
+      }
+
+      if (existingPerm) {
+        await ctx.db.patch(existingPerm._id, {
+          ...patchData,
+        });
+      } else {
+        await ctx.db.insert("effectivePermissions", {
+          tenantId: args.tenantId,
+          userId: args.userId,
+          permission: args.permission,
+          scopeKey,
+          scope: args.scope,
+          effect: "allow",
+          sources,
+          expiresAt: patchData.expiresAt as number | undefined,
+          policyResult: patchData.policyResult as "allow" | "deferred" | undefined,
+          policyName: patchData.policyName as string | undefined,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    } else if (existingPerm) {
+      await ctx.db.delete(existingPerm._id);
+    }
+
+    if (args.enableAudit) {
+      await ctx.db.insert("auditLog", {
+        tenantId: args.tenantId,
+        timestamp: now,
+        action: "permission_override_removed",
+        userId: args.userId,
+        actorId: args.removedBy,
+        details: {
+          permission: args.permission,
+          scope: args.scope,
+          reason: `override_removed:${existingOverride.effect}`,
+        },
+      });
+    }
+
+    return true;
   },
 });
 
@@ -2063,4 +2234,3 @@ export const syncRoleAction = action({
     return { usersProcessed: seen.size };
   },
 });
-


### PR DESCRIPTION
## Summary

Combines [#43](https://github.com/dbjpanda/convex-authz/pull/43) by @f-shindo (the core mutation + client method) with additional layers: example UI integration, broader test coverage, and an expanded README footgun warning. f-shindo's commit is preserved as-is on this branch — single squash-merge or merge-commit will land both contributions with proper authorship.

## Commits (in order)

| SHA | Author | What |
|---|---|---|
| `e722666` | @f-shindo | Core: `removeOverrideUnified` mutation + `Authz.removeOverride` client method, restoring role-derived sources / role expiry / deferred policy state correctly. README + tests. |
| `70cb96f` | dbjpanda | Example app: Permission Tester gains a Grant/Deny/Remove buttons panel that visibly demonstrates the API in real time via Convex's reactive queries. Browser-verified via Playwright. |
| `869cf55` | dbjpanda | Tests: 8 additional categories not covered by #43 — cross-tenant isolation, scope discrimination (global vs scoped), wildcard overrides, audit log fidelity, composability with v2.4 customRoles. |
| `6f1743b` | dbjpanda | README: expanded "Removing Permission Overrides" with footgun warning explaining why grant + deny aren't inverses. SKILL.md re-synced. |

## Why combine?

[#43](https://github.com/dbjpanda/convex-authz/pull/43) and the original [#46](https://github.com/dbjpanda/convex-authz/pull/46) independently fixed the same gap (no symmetric remove for grant/deny). After verifying #43's tests on a local checkout, three of its correctness behaviors are stronger than the original #46 (rebuilds sources from current roleAssignments, computes role-based expiry, restores deferred policy state). Rather than relitigating the API, this PR keeps #43's core unchanged and stacks the genuinely additive work on top.

## Test plan

- [x] `npm test` — **749 passing** (669 baseline + 8 from f-shindo's tests + 8 from added tests + 64 from v2.4 customRoles already on main)
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] Browser-verified end-to-end via Playwright on the example app (Grant → Deny → Remove flow + role-preservation case)

## Once this lands

[#43](https://github.com/dbjpanda/convex-authz/pull/43) can be closed since its commit is included here. release-please will roll the new `Features` line into the existing 2.4.0 release PR alongside the customRoles feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)